### PR TITLE
Mock Configuration / fix Maven Extension API version constant

### DIFF
--- a/first-party/layer-filter-extension/maven/build.gradle
+++ b/first-party/layer-filter-extension/maven/build.gradle
@@ -5,10 +5,10 @@ plugins {
 }
 
 dependencies {
-  compileOnly "com.google.cloud.tools:jib-maven-plugin-extension-api:${dependencyVersions.GRADLE_EXTENSION}"
+  compileOnly "com.google.cloud.tools:jib-maven-plugin-extension-api:${dependencyVersions.MAVEN_EXTENSION}"
   compileOnly "com.google.guava:guava:${dependencyVersions.GUAVA}"
 
-  testImplementation "com.google.cloud.tools:jib-maven-plugin-extension-api:${dependencyVersions.GRADLE_EXTENSION}"
+  testImplementation "com.google.cloud.tools:jib-maven-plugin-extension-api:${dependencyVersions.MAVEN_EXTENSION}"
   testImplementation "junit:junit:${dependencyVersions.JUNIT}"
   testImplementation "org.mockito:mockito-core:${dependencyVersions.MOCKITO_CORE}"
 }

--- a/first-party/layer-filter-extension/maven/src/main/java/com/google/cloud/tools/jib/plugins/extension/maven/layerfilter/Configuration.java
+++ b/first-party/layer-filter-extension/maven/src/main/java/com/google/cloud/tools/jib/plugins/extension/maven/layerfilter/Configuration.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.jib.plugins.extension.maven.layerfilter;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,21 +42,21 @@ import java.util.List;
 public class Configuration {
 
   public static class Filter {
-    @VisibleForTesting String glob = "";
-    @VisibleForTesting String toLayer = "";
+    private String glob = "";
+    private String toLayer = "";
 
-    String getGlob() {
+    public String getGlob() {
       return glob;
     }
 
-    String getToLayer() {
+    public String getToLayer() {
       return toLayer;
     }
   }
 
-  @VisibleForTesting List<Filter> filters = new ArrayList<>();
+  private List<Filter> filters = new ArrayList<>();
 
-  List<Filter> getFilters() {
+  public List<Filter> getFilters() {
     return filters;
   }
 }

--- a/first-party/layer-filter-extension/maven/src/test/java/com/google/cloud/tools/jib/plugins/extension/maven/layerfilter/JibLayerFilterExtensionTest.java
+++ b/first-party/layer-filter-extension/maven/src/test/java/com/google/cloud/tools/jib/plugins/extension/maven/layerfilter/JibLayerFilterExtensionTest.java
@@ -19,7 +19,9 @@ package com.google.cloud.tools.jib.plugins.extension.maven.layerfilter;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.buildplan.ContainerBuildPlan;
@@ -44,6 +46,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class JibLayerFilterExtensionTest {
 
+  @Mock private Configuration config;
   @Mock private MavenData mavenData;
   @Mock private ExtensionLogger logger;
 
@@ -78,8 +81,12 @@ public class JibLayerFilterExtensionTest {
   @Test
   public void testExtendContainerBuildPlan_noGlobGiven() {
     ContainerBuildPlan buildPlan = ContainerBuildPlan.builder().build();
-    Configuration config = new Configuration();
-    config.filters = Arrays.asList(new Configuration.Filter());
+
+    Configuration.Filter filter = mock(Configuration.Filter.class);
+    when(filter.getGlob()).thenReturn("");
+    when(filter.getToLayer()).thenReturn("doesn't matter");
+    when(config.getFilters()).thenReturn(Arrays.asList(filter));
+
     try {
       new JibLayerFilterExtension()
           .extendContainerBuildPlan(buildPlan, properties, Optional.of(config), mavenData, logger);
@@ -95,10 +102,9 @@ public class JibLayerFilterExtensionTest {
     FileEntriesLayer layer = buildLayer("same layer name", Arrays.asList("/foo"));
     ContainerBuildPlan buildPlan = ContainerBuildPlan.builder().addLayer(layer).build();
 
-    Configuration.Filter filter = new Configuration.Filter();
-    filter.toLayer = "same layer name";
-    Configuration config = new Configuration();
-    config.filters = Arrays.asList(filter);
+    Configuration.Filter filter = mock(Configuration.Filter.class);
+    when(filter.getToLayer()).thenReturn("same layer name");
+    when(config.getFilters()).thenReturn(Arrays.asList(filter));
 
     try {
       new JibLayerFilterExtension()
@@ -119,11 +125,10 @@ public class JibLayerFilterExtensionTest {
     FileEntriesLayer layer = buildLayer("" /* deliberately empty */, Arrays.asList("/foo"));
     ContainerBuildPlan buildPlan = ContainerBuildPlan.builder().addLayer(layer).build();
 
-    Configuration.Filter filter = new Configuration.Filter();
-    filter.glob = "nothing/matches";
-    filter.toLayer = "";
-    Configuration config = new Configuration();
-    config.filters = Arrays.asList(filter);
+    Configuration.Filter filter = mock(Configuration.Filter.class);
+    when(filter.getGlob()).thenReturn("nothing/matches");
+    when(filter.getToLayer()).thenReturn("");
+    when(config.getFilters()).thenReturn(Arrays.asList(filter));
 
     ContainerBuildPlan newPlan =
         new JibLayerFilterExtension()
@@ -141,10 +146,10 @@ public class JibLayerFilterExtensionTest {
     ContainerBuildPlan buildPlan =
         ContainerBuildPlan.builder().addLayer(layer1).addLayer(layer2).build();
 
-    Configuration.Filter filter = new Configuration.Filter();
-    filter.glob = "nothing/matches";
-    Configuration config = new Configuration();
-    config.filters = Arrays.asList(filter);
+    Configuration.Filter filter = mock(Configuration.Filter.class);
+    when(filter.getGlob()).thenReturn("nothing/matches");
+    when(filter.getToLayer()).thenReturn("");
+    when(config.getFilters()).thenReturn(Arrays.asList(filter));
 
     ContainerBuildPlan newPlan =
         new JibLayerFilterExtension()
@@ -168,10 +173,10 @@ public class JibLayerFilterExtensionTest {
     ContainerBuildPlan buildPlan =
         ContainerBuildPlan.builder().addLayer(layer1).addLayer(layer2).build();
 
-    Configuration.Filter filter = new Configuration.Filter();
-    filter.glob = "**";
-    Configuration config = new Configuration();
-    config.filters = Arrays.asList(filter);
+    Configuration.Filter filter = mock(Configuration.Filter.class);
+    when(filter.getGlob()).thenReturn("**");
+    when(filter.getToLayer()).thenReturn("");
+    when(config.getFilters()).thenReturn(Arrays.asList(filter));
 
     ContainerBuildPlan newPlan =
         new JibLayerFilterExtension()
@@ -188,23 +193,23 @@ public class JibLayerFilterExtensionTest {
         buildLayer("", Arrays.asList("/filter1", "/filter2", "/filter3", "/filter4", "/filter5"));
     ContainerBuildPlan buildPlan = ContainerBuildPlan.builder().addLayer(layer).build();
 
-    Configuration.Filter filter1 = new Configuration.Filter();
-    filter1.glob = "/filter1";
-    filter1.toLayer = "foo";
-    Configuration.Filter filter2 = new Configuration.Filter();
-    filter2.glob = "/filter2";
-    filter2.toLayer = "same layer name";
-    Configuration.Filter filter3 = new Configuration.Filter();
-    filter3.glob = "/filter3";
-    filter3.toLayer = "bar";
-    Configuration.Filter filter4 = new Configuration.Filter();
-    filter4.glob = "/filter4";
-    filter4.toLayer = "same layer name";
-    Configuration.Filter filter5 = new Configuration.Filter();
-    filter5.glob = "/filter5";
-    filter5.toLayer = "baz";
-    Configuration config = new Configuration();
-    config.filters = Arrays.asList(filter1, filter2, filter3, filter4, filter5);
+    Configuration.Filter filter1 = mock(Configuration.Filter.class);
+    when(filter1.getGlob()).thenReturn("/filter1");
+    when(filter1.getToLayer()).thenReturn("foo");
+    Configuration.Filter filter2 = mock(Configuration.Filter.class);
+    when(filter2.getGlob()).thenReturn("/filter2");
+    when(filter2.getToLayer()).thenReturn("same layer name");
+    Configuration.Filter filter3 = mock(Configuration.Filter.class);
+    when(filter3.getGlob()).thenReturn("/filter3");
+    when(filter3.getToLayer()).thenReturn("bar");
+    Configuration.Filter filter4 = mock(Configuration.Filter.class);
+    when(filter4.getGlob()).thenReturn("/filter4");
+    when(filter4.getToLayer()).thenReturn("same layer name");
+    Configuration.Filter filter5 = mock(Configuration.Filter.class);
+    when(filter5.getGlob()).thenReturn("/filter5");
+    when(filter5.getToLayer()).thenReturn("baz");
+    when(config.getFilters())
+        .thenReturn(Arrays.asList(filter1, filter2, filter3, filter4, filter5));
 
     JibLayerFilterExtension extension = new JibLayerFilterExtension();
     ContainerBuildPlan newPlan =
@@ -236,14 +241,13 @@ public class JibLayerFilterExtensionTest {
     FileEntriesLayer layer = buildLayer("extra files", Arrays.asList("/foo"));
     ContainerBuildPlan buildPlan = ContainerBuildPlan.builder().addLayer(layer).build();
 
-    Configuration.Filter filter1 = new Configuration.Filter();
-    filter1.glob = "**";
-    filter1.toLayer = "looser";
-    Configuration.Filter filter2 = new Configuration.Filter();
-    filter2.glob = "**";
-    filter2.toLayer = "winner";
-    Configuration config = new Configuration();
-    config.filters = Arrays.asList(filter1, filter2);
+    Configuration.Filter filter1 = mock(Configuration.Filter.class);
+    when(filter1.getGlob()).thenReturn("**");
+    when(filter1.getToLayer()).thenReturn("looser");
+    Configuration.Filter filter2 = mock(Configuration.Filter.class);
+    when(filter2.getGlob()).thenReturn("**");
+    when(filter2.getToLayer()).thenReturn("winner");
+    when(config.getFilters()).thenReturn(Arrays.asList(filter1, filter2));
 
     ContainerBuildPlan newPlan =
         new JibLayerFilterExtension()
@@ -273,25 +277,26 @@ public class JibLayerFilterExtensionTest {
             .setLayers(Arrays.asList(layer1, layer2, layer3, layer4))
             .build();
 
-    Configuration.Filter filter1 = new Configuration.Filter();
-    filter1.glob = "/alpha/**";
-    filter1.toLayer = "alpha Alice";
-    Configuration.Filter filter2 = new Configuration.Filter();
-    filter2.glob = "/?????/*";
-    filter2.toLayer = "alpha gamma";
-    Configuration.Filter filter3 = new Configuration.Filter();
-    filter3.glob = "**/Bob";
-    filter3.toLayer = "Bob";
-    Configuration.Filter filter4 = new Configuration.Filter();
-    filter4.glob = "/gamma/C*";
-    filter4.toLayer = "gamma Charlie";
-    Configuration.Filter filter5 = new Configuration.Filter();
-    filter5.glob = "**/Alice";
-    filter5.toLayer = "alpha Alice";
-    Configuration.Filter filter6 = new Configuration.Filter();
-    filter6.glob = "**/David";
-    Configuration config = new Configuration();
-    config.filters = Arrays.asList(filter1, filter2, filter3, filter4, filter5, filter6);
+    Configuration.Filter filter1 = mock(Configuration.Filter.class);
+    when(filter1.getGlob()).thenReturn("/alpha/**");
+    when(filter1.getToLayer()).thenReturn("alpha Alice");
+    Configuration.Filter filter2 = mock(Configuration.Filter.class);
+    when(filter2.getGlob()).thenReturn("/?????/*");
+    when(filter2.getToLayer()).thenReturn("alpha gamma");
+    Configuration.Filter filter3 = mock(Configuration.Filter.class);
+    when(filter3.getGlob()).thenReturn("**/Bob");
+    when(filter3.getToLayer()).thenReturn("Bob");
+    Configuration.Filter filter4 = mock(Configuration.Filter.class);
+    when(filter4.getGlob()).thenReturn("/gamma/C*");
+    when(filter4.getToLayer()).thenReturn("gamma Charlie");
+    Configuration.Filter filter5 = mock(Configuration.Filter.class);
+    when(filter5.getGlob()).thenReturn("**/Alice");
+    when(filter5.getToLayer()).thenReturn("alpha Alice");
+    Configuration.Filter filter6 = mock(Configuration.Filter.class);
+    when(filter6.getGlob()).thenReturn("**/David");
+    when(filter6.getToLayer()).thenReturn("");
+    when(config.getFilters())
+        .thenReturn(Arrays.asList(filter1, filter2, filter3, filter4, filter5, filter6));
 
     ContainerBuildPlan newPlan =
         new JibLayerFilterExtension()

--- a/first-party/ownership-extension/maven/build.gradle
+++ b/first-party/ownership-extension/maven/build.gradle
@@ -5,10 +5,9 @@ plugins {
 }
 
 dependencies {
-  compileOnly "com.google.cloud.tools:jib-maven-plugin-extension-api:${dependencyVersions.GRADLE_EXTENSION}"
-  compileOnly "com.google.guava:guava:${dependencyVersions.GUAVA}"
+  compileOnly "com.google.cloud.tools:jib-maven-plugin-extension-api:${dependencyVersions.MAVEN_EXTENSION}"
 
-  testImplementation "com.google.cloud.tools:jib-maven-plugin-extension-api:${dependencyVersions.GRADLE_EXTENSION}"
+  testImplementation "com.google.cloud.tools:jib-maven-plugin-extension-api:${dependencyVersions.MAVEN_EXTENSION}"
   testImplementation "junit:junit:${dependencyVersions.JUNIT}"
   testImplementation "org.mockito:mockito-core:${dependencyVersions.MOCKITO_CORE}"
 }

--- a/first-party/ownership-extension/maven/src/main/java/com/google/cloud/tools/jib/plugins/extension/maven/ownership/Configuration.java
+++ b/first-party/ownership-extension/maven/src/main/java/com/google/cloud/tools/jib/plugins/extension/maven/ownership/Configuration.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.jib.plugins.extension.maven.ownership;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,21 +44,21 @@ import java.util.List;
 public class Configuration {
 
   public static class Rule {
-    @VisibleForTesting String glob = "";
-    @VisibleForTesting String ownership = "";
+    private String glob = "";
+    private String ownership = "";
 
-    String getGlob() {
+    public String getGlob() {
       return glob;
     }
 
-    String getOwnership() {
+    public String getOwnership() {
       return ownership;
     }
   }
 
-  @VisibleForTesting List<Rule> rules = new ArrayList<>();
+  private List<Rule> rules = new ArrayList<>();
 
-  List<Rule> getRules() {
+  public List<Rule> getRules() {
     return rules;
   }
 }

--- a/first-party/ownership-extension/maven/src/test/java/com/google/cloud/tools/jib/plugins/extension/maven/ownership/JibOwnershipExtensionTest.java
+++ b/first-party/ownership-extension/maven/src/test/java/com/google/cloud/tools/jib/plugins/extension/maven/ownership/JibOwnershipExtensionTest.java
@@ -19,7 +19,9 @@ package com.google.cloud.tools.jib.plugins.extension.maven.ownership;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.buildplan.ContainerBuildPlan;
@@ -44,6 +46,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class JibOwnershipExtensionTest {
 
+  @Mock private Configuration config;
   @Mock private MavenData mavenData;
   @Mock private ExtensionLogger logger;
 
@@ -67,8 +70,11 @@ public class JibOwnershipExtensionTest {
   @Test
   public void testExtendContainerBuildPlan_noGlobGiven() {
     ContainerBuildPlan buildPlan = ContainerBuildPlan.builder().build();
-    Configuration config = new Configuration();
-    config.rules = Arrays.asList(new Configuration.Rule());
+
+    Configuration.Rule rule = mock(Configuration.Rule.class);
+    when(rule.getGlob()).thenReturn("");
+    when(config.getRules()).thenReturn(Arrays.asList(rule));
+
     try {
       new JibOwnershipExtension()
           .extendContainerBuildPlan(buildPlan, properties, Optional.of(config), mavenData, logger);
@@ -102,14 +108,13 @@ public class JibOwnershipExtensionTest {
     ContainerBuildPlan buildPlan =
         ContainerBuildPlan.builder().addLayer(layer1).addLayer(layer2).build();
 
-    Configuration.Rule rule1 = new Configuration.Rule();
-    rule1.glob = "/target/**";
-    rule1.ownership = "10:20";
-    Configuration.Rule rule2 = new Configuration.Rule();
-    rule2.glob = "**/bar";
-    rule2.ownership = "999:777";
-    Configuration config = new Configuration();
-    config.rules = Arrays.asList(rule1, rule2);
+    Configuration.Rule rule1 = mock(Configuration.Rule.class);
+    when(rule1.getGlob()).thenReturn("/target/**");
+    when(rule1.getOwnership()).thenReturn("10:20");
+    Configuration.Rule rule2 = mock(Configuration.Rule.class);
+    when(rule2.getGlob()).thenReturn("**/bar");
+    when(rule2.getOwnership()).thenReturn("999:777");
+    when(config.getRules()).thenReturn(Arrays.asList(rule1, rule2));
 
     ContainerBuildPlan newPlan =
         new JibOwnershipExtension()
@@ -154,14 +159,13 @@ public class JibOwnershipExtensionTest {
             .build();
     ContainerBuildPlan buildPlan = ContainerBuildPlan.builder().addLayer(layer).build();
 
-    Configuration.Rule rule1 = new Configuration.Rule();
-    rule1.glob = "**";
-    rule1.ownership = "10:20";
-    Configuration.Rule rule2 = new Configuration.Rule();
-    rule2.glob = "**";
-    rule2.ownership = "999:777";
-    Configuration config = new Configuration();
-    config.rules = Arrays.asList(rule1, rule2);
+    Configuration.Rule rule1 = mock(Configuration.Rule.class);
+    when(rule1.getGlob()).thenReturn("**");
+    when(rule1.getOwnership()).thenReturn("10:20");
+    Configuration.Rule rule2 = mock(Configuration.Rule.class);
+    when(rule2.getGlob()).thenReturn("**");
+    when(rule2.getOwnership()).thenReturn("999:777");
+    when(config.getRules()).thenReturn(Arrays.asList(rule1, rule2));
 
     ContainerBuildPlan newPlan =
         new JibOwnershipExtension()


### PR DESCRIPTION
- Mock `Configuration` rather than making fields visible.
- Fix using a wrong API version constant in `build.gradle`.
- Remove Guava dep from the ownership extension.