### PR TITLE
Document Kotlin usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,31 +72,31 @@ Some extensions may expect you to provide extension-specific user configuration.
 
 - For extensions that accept simple string properties (map), use `<pluginExtension><properties>`. For example,
    ```xml
-           <pluginExtension>
-             <implementation>com.example.ExtensionAcceptingMapConfig</implementation>
-             <properties>
-               <customFlag>true</customFlag>
-               <layerName>samples</layerName>
-             </properties>
-           </pluginExtension>
+   <pluginExtension>
+     <implementation>com.example.ExtensionAcceptingMapConfig</implementation>
+     <properties>
+       <customFlag>true</customFlag>
+       <layerName>samples</layerName>
+     </properties>
+   </pluginExtension>
    ```
 - For extensions that define a complex configuration, use `<pluginExtension><configuration implementation=...>` (not Jib's `<configuration>`). Note that the class for the `implementation` XML attribute should be the extension-supplied configuration class and not the main extension class. For example,
    ```xml
-           <pluginExtension>
-             <implementation>com.google.cloud.tools.jib.maven.extension.layerfilter.JibLayerFilterExtension</implementation>
-             <configuration implementation="com.google.cloud.tools.jib.maven.extension.layerfilter.Configuration">
-               <filters>
-                 <filter>
-                   <glob>**/google-*.jar</glob>
-                   <toLayer>google libraries</toLayer>
-                 </filter>
-                 <filter>
-                   <glob>/app/libs/in-house-*.jar</glob>
-                   <toLayer>in-house dependencies</toLayer>
-                 </filter>
-               </filters>
-             </configuration>
-         </pluginExtension>
+   <pluginExtension>
+     <implementation>com.google.cloud.tools.jib.maven.extension.layerfilter.JibLayerFilterExtension</implementation>
+     <configuration implementation="com.google.cloud.tools.jib.maven.extension.layerfilter.Configuration">
+       <filters>
+         <filter>
+           <glob>**/google-*.jar</glob>
+           <toLayer>google libraries</toLayer>
+         </filter>
+         <filter>
+           <glob>/app/libs/in-house-*.jar</glob>
+           <toLayer>in-house dependencies</toLayer>
+         </filter>
+       </filters>
+     </configuration>
+   </pluginExtension>
    ```
 
 ### Gradle<a name="using-jib-plugin-extensions-gradle"></a>
@@ -135,49 +135,49 @@ Some extensions may expect you to provide extension-specific user configuration.
 
 - For extensions that accept simple string properties (map), use `pluginExtension.properties`. For example,
    ```gradle
-     pluginExtensions {
-       pluginExtension {
-         implementation = 'com.example.ExtensionAcceptingMapConfig'
-         properties = [customFlag: 'true', layerName: 'samples']
-       }
+   pluginExtensions {
+     pluginExtension {
+       implementation = 'com.example.ExtensionAcceptingMapConfig'
+       properties = [customFlag: 'true', layerName: 'samples']
      }
+   }
    ```
 - For extensions that define a complex configuration, use `pluginExtension.configuration`. For example,
    - Groovy
       ```gradle
-          pluginExtension {
-            implementation = 'com.google.cloud.tools.jib.gradle.extension.layerfilter.JibLayerFilterExtension'
-            configuration {
-              filters {
-                filter {
-                  glob = '**/google-*.jar'
-                  toLayer = 'google libraries'
-                }
-                filter {
-                  glob = '/app/libs/in-house-*.jar'
-                  toLayer = 'in-house dependencies'
-                }
-              }
+      pluginExtension {
+        implementation = 'com.google.cloud.tools.jib.gradle.extension.layerfilter.JibLayerFilterExtension'
+        configuration {
+          filters {
+            filter {
+              glob = '**/google-*.jar'
+              toLayer = 'google libraries'
+            }
+            filter {
+              glob = '/app/libs/in-house-*.jar'
+              toLayer = 'in-house dependencies'
             }
           }
+        }
+      }
       ```
    - Kotlin
       ```kotlin
-          pluginExtension {
-            implementation = "com.google.cloud.tools.jib.gradle.extension.layerfilter.JibLayerFilterExtension"
-            configuration(Action<com.google.cloud.tools.jib.gradle.extension.layerfilter.Configuration> {
-              filters {
-                filter {
-                  glob = "**/google-*.jar"
-                  toLayer = "google libraries"
-                }
-                filter {
-                  glob = "/app/libs/in-house-*.jar"
-                  toLayer = "in-house dependencies"
-                }
-              }
+      pluginExtension {
+        implementation = "com.google.cloud.tools.jib.gradle.extension.layerfilter.JibLayerFilterExtension"
+        configuration(Action<com.google.cloud.tools.jib.gradle.extension.layerfilter.Configuration> {
+          filters {
+            filter {
+              glob = "**/google-*.jar"
+              toLayer = "google libraries"
+            }
+            filter {
+              glob = "/app/libs/in-house-*.jar"
+              toLayer = "in-house dependencies"
             }
           }
+        })
+      }
       ```
 
 ## Writing Your Own Extensions

--- a/README.md
+++ b/README.md
@@ -143,23 +143,42 @@ Some extensions may expect you to provide extension-specific user configuration.
      }
    ```
 - For extensions that define a complex configuration, use `pluginExtension.configuration`. For example,
-   ```gradle
-       pluginExtension {
-         implementation = 'com.google.cloud.tools.jib.gradle.extension.layerfilter.JibLayerFilterExtension'
-         configuration {
-           filters {
-             filter {
-               glob = '**/google-*.jar'
-               toLayer = 'google libraries'
-             }
-             filter {
-               glob = '/app/libs/in-house-*.jar'
-               toLayer = 'in-house dependencies'
-             }
-           }
-         }
-       }
-   ```
+   - Groovy
+      ```gradle
+          pluginExtension {
+            implementation = 'com.google.cloud.tools.jib.gradle.extension.layerfilter.JibLayerFilterExtension'
+            configuration {
+              filters {
+                filter {
+                  glob = '**/google-*.jar'
+                  toLayer = 'google libraries'
+                }
+                filter {
+                  glob = '/app/libs/in-house-*.jar'
+                  toLayer = 'in-house dependencies'
+                }
+              }
+            }
+          }
+      ```
+   - Kotlin
+      ```kotlin
+          pluginExtension {
+            implementation = "com.google.cloud.tools.jib.gradle.extension.layerfilter.JibLayerFilterExtension"
+            configuration(Action<com.google.cloud.tools.jib.gradle.extension.layerfilter.Configuration> {
+              filters {
+                filter {
+                  glob = "**/google-*.jar"
+                  toLayer = "google libraries"
+                }
+                filter {
+                  glob = "/app/libs/in-house-*.jar"
+                  toLayer = "in-house dependencies"
+                }
+              }
+            }
+          }
+      ```
 
 ## Writing Your Own Extensions
 

--- a/first-party/jib-layer-filter-extension-gradle/README.md
+++ b/first-party/jib-layer-filter-extension-gradle/README.md
@@ -65,7 +65,7 @@ Kotlin requires specifying the type for `pluginExtension.configuration`.
         }
         ...
       }
-    }
+    })
   }
 ```
 

--- a/first-party/jib-layer-filter-extension-gradle/README.md
+++ b/first-party/jib-layer-filter-extension-gradle/README.md
@@ -53,6 +53,22 @@ jib {
 }
 ```
 
+Kotlin requires specifying the type for `pluginExtension.configuration`.
+
+```kotlin
+  pluginExtension {
+    implementation = "com.google.cloud.tools.jib.gradle.extension.layerfilter.JibLayerFilterExtension"
+    configuration(Action<com.google.cloud.tools.jib.gradle.extension.layerfilter.Configuration> {
+      filters {
+        filter {
+          glob = "**/*.jar"
+        }
+        ...
+      }
+    }
+  }
+```
+
 ## Detailed Filtering Rules
 
 - If multiple filters match a file, the last filter in the order applies to the file.

--- a/first-party/jib-ownership-extension-gradle/README.md
+++ b/first-party/jib-ownership-extension-gradle/README.md
@@ -53,7 +53,7 @@ Kotlin requires specifying the type for `pluginExtension.configuration`.
         }
         ...
       }
-    }
+    })
   }
 ```
 

--- a/first-party/jib-ownership-extension-gradle/README.md
+++ b/first-party/jib-ownership-extension-gradle/README.md
@@ -40,6 +40,23 @@ jib {
 }
 ```
 
+Kotlin requires specifying the type for `pluginExtension.configuration`.
+
+```kotlin
+  pluginExtension {
+    implementation = "com.google.cloud.tools.jib.gradle.extension.ownership.JibOwnershipExtension"
+    configuration(Action<com.google.cloud.tools.jib.gradle.extension.ownership.Configuration> {
+      rules {
+        rule {
+          glob = "/app/classes/**"
+          ownership = "300"
+        }
+        ...
+      }
+    }
+  }
+```
+
 ## Known Issues
 
 #### Unable to change ownership of some parent directories.


### PR DESCRIPTION
Fixes #35.

This is not worse than Maven, where they have to do a similar thing:

```xml
      <pluginExtension>
        <implementation>com.google.cloud.tools.jib.maven.extension.ownership.JibOwnershipExtension</implementation>
        <configuration implementation="com.google.cloud.tools.jib.maven.extension.ownership.Configuration">
          <rules>
            <rule>
```