### PR TITLE
Quarkus Gradle: fix exception when jib.container.appRoot is not configured

### DIFF
--- a/first-party/jib-quarkus-extension-gradle/src/main/java/com/google/cloud/tools/jib/gradle/extension/quarkus/JibQuarkusExtension.java
+++ b/first-party/jib-quarkus-extension-gradle/src/main/java/com/google/cloud/tools/jib/gradle/extension/quarkus/JibQuarkusExtension.java
@@ -26,6 +26,7 @@ import com.google.cloud.tools.jib.gradle.extension.JibGradlePluginExtension;
 import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger;
 import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger.LogLevel;
 import com.google.cloud.tools.jib.plugins.extension.JibPluginExtensionException;
+import com.google.common.base.Strings;
 import com.google.common.base.Verify;
 import java.io.File;
 import java.io.IOException;
@@ -172,7 +173,10 @@ public class JibQuarkusExtension implements JibGradlePluginExtension<Void> {
 
   private void readJibConfigurations(Project project) {
     JibExtension jibPlugin = project.getExtensions().findByType(JibExtension.class);
-    appRoot = AbsoluteUnixPath.get(jibPlugin.getContainer().getAppRoot());
+    String appRootValue = jibPlugin.getContainer().getAppRoot();
+    if (!Strings.isNullOrEmpty(appRootValue)) {
+      appRoot = AbsoluteUnixPath.get(appRootValue);
+    }
     jvmFlags = jibPlugin.getContainer().getJvmFlags();
   }
 }

--- a/first-party/jib-quarkus-extension-gradle/src/test/java/com/google/cloud/tools/jib/gradle/extension/quarkus/JibQuarkusExtensionTest.java
+++ b/first-party/jib-quarkus-extension-gradle/src/test/java/com/google/cloud/tools/jib/gradle/extension/quarkus/JibQuarkusExtensionTest.java
@@ -142,6 +142,20 @@ public class JibQuarkusExtensionTest {
   }
 
   @Test
+  public void testExtendContainerBuildPlan_emptyAppRoot() throws JibPluginExtensionException {
+    when(jibPlugin.getContainer().getAppRoot()).thenReturn("");
+
+    ContainerBuildPlan buildPlan = ContainerBuildPlan.builder().build();
+    ContainerBuildPlan newPlan =
+        new JibQuarkusExtension()
+            .extendContainerBuildPlan(buildPlan, null, Optional.empty(), gradleData, logger);
+
+    assertEquals(
+        Arrays.asList("java", "-verbose:gc", "-Dmy.property=value", "-jar", "/app/app.jar"),
+        newPlan.getEntrypoint());
+  }
+
+  @Test
   public void testExtendContainerBuildPlan_noQuarkusRunnerJar() throws IOException {
     Files.delete(tempFolder.getRoot().toPath().resolve("build").resolve("my-app-runner.jar"));
     ContainerBuildPlan buildPlan = ContainerBuildPlan.builder().build();


### PR DESCRIPTION
Fixes #50.

I've verified that the Maven extension doesn't suffer from the same issue.