### PR TITLE
Added third party extension for packaging type "bundle"

### DIFF
--- a/third-party/README.md
+++ b/third-party/README.md
@@ -6,6 +6,7 @@ If you have written a useful extension that you think will benefit the Jib commu
 
 Got interested in writing an extension? It's easy! Take a look at ["Writing Your Own Extensions"](../README.md#writing-your-own-extensions).
 
+- [Bundle Packaging Plugin Extension](https://github.com/thought-gang/jib-maven-plugin-extension.git) - An extension to suppport the Maven packaging type "bundle"
 - to be added
 - ... 
 - ...


### PR DESCRIPTION
I have added a link to an extension to create images for the packaging type "bundle". See [jib issue #2562](https://github.com/GoogleContainerTools/jib/issues/2562)