### PR TITLE
Use `-Prelease.useAutomaticVersion=true` for non-interactive release and remove unnecessary branch and tag pushes

### DIFF
--- a/first-party/scripts/prepare_release.sh
+++ b/first-party/scripts/prepare_release.sh
@@ -60,10 +60,6 @@ git checkout -b ${BRANCH}
   -Prelease.releaseVersion=${VERSION} \
   ${POST_RELEASE_VERSION:+"-Prelease.newVersion=${POST_RELEASE_VERSION}"}
 
-# Pushes the release branch and tag to Github.
-git push origin ${BRANCH}
-git push origin v${VERSION}-${PROJECT}
-
 # File a PR on Github for the new branch. Have someone LGTM it, which gives you permission to continue.
 EchoGreen 'File a PR for the new release branch:'
 echo https://github.com/GoogleContainerTools/jib-extensions/pull/new/${BRANCH}

--- a/first-party/scripts/prepare_release.sh
+++ b/first-party/scripts/prepare_release.sh
@@ -55,7 +55,10 @@ BRANCH=${PROJECT}-release-v${VERSION}
 git checkout -b ${BRANCH}
 
 # Changes the version for release and creates the commits/tags.
-echo | ./gradlew :${PROJECT}:release -Prelease.releaseVersion=${VERSION} ${POST_RELEASE_VERSION:+"-Prelease.newVersion=${POST_RELEASE_VERSION}"}
+./gradlew :${PROJECT}:release \
+  -Prelease.useAutomaticVersion=true \
+  -Prelease.releaseVersion=${VERSION} \
+  ${POST_RELEASE_VERSION:+"-Prelease.newVersion=${POST_RELEASE_VERSION}"}
 
 # Pushes the release branch and tag to Github.
 git push origin ${BRANCH}


### PR DESCRIPTION
We've been using `echo | ./gradlew release` to suppress interactive prompts, but we can use [`-Prelease.useAutomaticVersion=true`](https://github.com/researchgate/gradle-release#working-in-continuous-integration) instead.

Also learned that the `release` task pushes the branch and the tag, so no need to manually push them.