### PR TITLE
jib-layer-filter-extension-maven: optionally create separate layers for dependencies from parent POM

### DIFF
--- a/first-party/jib-layer-filter-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/layerfilter/Configuration.java
+++ b/first-party/jib-layer-filter-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/layerfilter/Configuration.java
@@ -36,7 +36,7 @@ import java.util.List;
  *       <toLayer>in-house dependencies</toLayer>
  *     </filter>
  *   </filters>
- *   <createParentLayers>true</createParentLayers>
+ *   <createParentDependencyLayers>true</createParentDependencyLayers>
  * </configuration>
  * }</pre>
  */
@@ -62,17 +62,13 @@ public class Configuration {
    * layers are created after the filters have been applied. For every original layer and every
    * layer defined by the filters, a parent layer will be created (if not empty).
    */
-  private boolean createParentLayers;
+  private boolean createParentDependencyLayers;
 
   public List<Filter> getFilters() {
     return filters;
   }
 
-  public boolean isCreateParentLayers() {
-    return createParentLayers;
-  }
-
-  public void setCreateParentLayers(boolean parentLayers) {
-    this.createParentLayers = parentLayers;
+  public boolean isCreateParentDependencyLayers() {
+    return createParentDependencyLayers;
   }
 }

--- a/first-party/jib-layer-filter-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/layerfilter/Configuration.java
+++ b/first-party/jib-layer-filter-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/layerfilter/Configuration.java
@@ -36,6 +36,7 @@ import java.util.List;
  *       <toLayer>in-house dependencies</toLayer>
  *     </filter>
  *   </filters>
+ *   <createParentLayers>true</createParentLayers>
  * </configuration>
  * }</pre>
  */
@@ -56,7 +57,22 @@ public class Configuration {
 
   private List<Filter> filters = new ArrayList<>();
 
+  /**
+   * Whether to create separate layers for dependencies that stem from the parent POM. The parent
+   * layers are created after the filters have been applied. For every original layer and every
+   * layer defined by the filters, a parent layer will be created (if not empty).
+   */
+  private boolean createParentLayers;
+
   public List<Filter> getFilters() {
     return filters;
+  }
+
+  public boolean isCreateParentLayers() {
+    return createParentLayers;
+  }
+
+  public void setCreateParentLayers(boolean parentLayers) {
+    this.createParentLayers = parentLayers;
   }
 }

--- a/first-party/jib-layer-filter-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/layerfilter/JibLayerFilterExtension.java
+++ b/first-party/jib-layer-filter-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/layerfilter/JibLayerFilterExtension.java
@@ -145,6 +145,7 @@ public class JibLayerFilterExtension implements JibMavenPluginExtension<Configur
             .map(d -> d.getArtifact())
             // TODO: configurable?
             .collect(
+                // TODO: getVersion or getBaseVersion? check in jib, which version it is...
                 Collectors.toMap(
                     a -> "/app/libs/" + a.getArtifactId() + "-" + a.getVersion() + ".jar", a -> a));
 
@@ -187,7 +188,7 @@ public class JibLayerFilterExtension implements JibMavenPluginExtension<Configur
 
     parentDependenciesNotFound.forEach(
         (path, artifact) -> {
-          logger.log(LogLevel.ERROR, "Dependency from parent not found: " + artifact);
+          logger.log(LogLevel.ERROR, "Dependency from parent not found: " + path);
         });
 
     return buildPlanWithNewLayers(buildPlan, newLayers);

--- a/first-party/jib-layer-filter-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/layerfilter/JibLayerFilterExtension.java
+++ b/first-party/jib-layer-filter-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/layerfilter/JibLayerFilterExtension.java
@@ -143,7 +143,7 @@ public class JibLayerFilterExtension implements JibMavenPluginExtension<Configur
                         "/app/libs/"
                             + artifact.getArtifactId()
                             + "-"
-                            + artifact.getVersion()
+                            + artifact.getBaseVersion()
                             + ".jar",
                     artifact -> artifact));
 

--- a/first-party/jib-layer-filter-extension-maven/src/main/resources/META-INF/sisu/javax.inject.Named
+++ b/first-party/jib-layer-filter-extension-maven/src/main/resources/META-INF/sisu/javax.inject.Named
@@ -1,0 +1,1 @@
+com.google.cloud.tools.jib.maven.extension.layerfilter.JibLayerFilterExtension

--- a/first-party/jib-layer-filter-extension-maven/src/test/java/com/google/cloud/tools/jib/maven/extension/layerfilter/JibLayerFilterExtensionTest.java
+++ b/first-party/jib-layer-filter-extension-maven/src/test/java/com/google/cloud/tools/jib/maven/extension/layerfilter/JibLayerFilterExtensionTest.java
@@ -441,6 +441,6 @@ public class JibLayerFilterExtensionTest {
     verify(logger)
         .log(
             LogLevel.INFO,
-            "Dependency from parent not found: /app/libs/parent-lib-different-version-1.0.0.jar");
+            "Dependency from parent not found: parent-lib-different-version-1.0.0.jar");
   }
 }

--- a/first-party/jib-layer-filter-extension-maven/src/test/java/com/google/cloud/tools/jib/maven/extension/layerfilter/JibLayerFilterExtensionTest.java
+++ b/first-party/jib-layer-filter-extension-maven/src/test/java/com/google/cloud/tools/jib/maven/extension/layerfilter/JibLayerFilterExtensionTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.jib.maven.extension.layerfilter;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
@@ -390,8 +391,13 @@ public class JibLayerFilterExtensionTest {
   public void testExtendContainerBuildPlan_createParentLayers_withParentDependencies()
       throws JibPluginExtensionException {
     FileEntriesLayer layer1 =
-        buildLayer("layer1", Arrays.asList("/app/libs/foo-1.0.0.jar", "/app/libs/bar-2.0.0.jar", "/app/libs/wrong-version-2.0.0.jar"));
-    FileEntriesLayer layer2 = buildLayer("layer2", Arrays.asList("/app/libs/blah-3.0.0.jar"));
+        buildLayer(
+            "layer1",
+            asList(
+                "/app/libs/foo-1.0.0.jar",
+                "/app/libs/bar-2.0.0.jar",
+                "/app/libs/wrong-version-2.0.0.jar"));
+    FileEntriesLayer layer2 = buildLayer("layer2", asList("/app/libs/blah-3.0.0.jar"));
 
     ContainerBuildPlan buildPlan =
         ContainerBuildPlan.builder().addLayer(layer1).addLayer(layer2).build();
@@ -404,7 +410,7 @@ public class JibLayerFilterExtensionTest {
     Dependency wrongVersionDependency = mockDependency("wrong-version", "1.0.0");
 
     when(dependencyResolutionResult.getDependencies())
-        .thenReturn(Arrays.asList(fooDependency, blahDependency, wrongVersionDependency));
+        .thenReturn(asList(fooDependency, blahDependency, wrongVersionDependency));
 
     JibLayerFilterExtension extension = new JibLayerFilterExtension();
     extension.setDependencyResolver(projectDependenciesResolver);
@@ -415,10 +421,11 @@ public class JibLayerFilterExtensionTest {
     assertEquals(3, newPlan.getLayers().size());
 
     List<FileEntriesLayer> expectedNewLayers =
-        Arrays.asList(
-            buildLayer("layer1-parent", Arrays.asList("/app/libs/foo-1.0.0.jar")),
-            buildLayer("layer1", Arrays.asList("/app/libs/bar-2.0.0.jar", "/app/libs/wrong-version-2.0.0.jar")),
-            buildLayer("layer2-parent", Arrays.asList("/app/libs/blah-3.0.0.jar")));
+        asList(
+            buildLayer("layer1-parent", asList("/app/libs/foo-1.0.0.jar")),
+            buildLayer(
+                "layer1", asList("/app/libs/bar-2.0.0.jar", "/app/libs/wrong-version-2.0.0.jar")),
+            buildLayer("layer2-parent", asList("/app/libs/blah-3.0.0.jar")));
 
     for (int i = 0; i < expectedNewLayers.size(); i++) {
       assertEquals(expectedNewLayers.get(i).getName(), newPlan.getLayers().get(i).getName());
@@ -426,7 +433,8 @@ public class JibLayerFilterExtensionTest {
           expectedNewLayers.get(i).getEntries(),
           ((FileEntriesLayer) newPlan.getLayers().get(i)).getEntries());
     }
-    
-    verify(logger).log(LogLevel.ERROR, "Dependency from parent not found: /app/libs/wrong-version-1.0.0.jar");
+
+    verify(logger)
+        .log(LogLevel.ERROR, "Dependency from parent not found: /app/libs/wrong-version-1.0.0.jar");
   }
 }

--- a/first-party/jib-layer-filter-extension-maven/src/test/java/com/google/cloud/tools/jib/maven/extension/layerfilter/JibLayerFilterExtensionTest.java
+++ b/first-party/jib-layer-filter-extension-maven/src/test/java/com/google/cloud/tools/jib/maven/extension/layerfilter/JibLayerFilterExtensionTest.java
@@ -32,7 +32,6 @@ import com.google.cloud.tools.jib.maven.extension.MavenData;
 import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger;
 import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger.LogLevel;
 import com.google.cloud.tools.jib.plugins.extension.JibPluginExtensionException;
-import java.io.File;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -70,7 +69,6 @@ public class JibLayerFilterExtensionTest {
   @Before
   public void setUp() throws DependencyResolutionException {
     when(config.getFilters()).thenReturn(Collections.emptyList());
-    when(config.isCreateParentDependencyLayers()).thenReturn(false);
     when(mavenData.getMavenProject()).thenReturn(mavenProject);
     when(mavenData.getMavenSession()).thenReturn(mavenSession);
     when(mavenProject.getParent()).thenReturn(mavenParentProject);
@@ -112,11 +110,9 @@ public class JibLayerFilterExtensionTest {
   }
 
   private static Dependency mockDependency(String sourcePath, String artifactId) {
-    File file = mock(File.class);
-    when(file.toPath()).thenReturn(Paths.get(sourcePath));
     Artifact artifact = mock(Artifact.class);
     when(artifact.getArtifactId()).thenReturn(artifactId);
-    when(artifact.getFile()).thenReturn(file);
+    when(artifact.getFile()).thenReturn(Paths.get(sourcePath).toFile());
     return new Dependency(artifact, null);
   }
 
@@ -367,8 +363,6 @@ public class JibLayerFilterExtensionTest {
 
     try {
       JibLayerFilterExtension extension = new JibLayerFilterExtension();
-      extension.dependencyResolver = projectDependenciesResolver;
-
       extension.extendContainerBuildPlan(buildPlan, null, Optional.of(config), mavenData, logger);
       fail();
     } catch (JibPluginExtensionException ex) {

--- a/first-party/jib-layer-filter-extension-maven/src/test/java/com/google/cloud/tools/jib/maven/extension/layerfilter/JibLayerFilterExtensionTest.java
+++ b/first-party/jib-layer-filter-extension-maven/src/test/java/com/google/cloud/tools/jib/maven/extension/layerfilter/JibLayerFilterExtensionTest.java
@@ -103,7 +103,7 @@ public class JibLayerFilterExtensionTest {
   private static Dependency mockDependency(String artifactId, String version) {
     Artifact artifact = mock(Artifact.class);
     when(artifact.getArtifactId()).thenReturn(artifactId);
-    when(artifact.getVersion()).thenReturn(version);
+    when(artifact.getBaseVersion()).thenReturn(version);
     return new Dependency(artifact, null);
   }
 


### PR DESCRIPTION
I would like to achieve the following:

- determine the dependencies (including transitive) that come from the parent pom
- put them into one or more separate layers

The idea is that the parent pom defines the "company / project standard" which rarely changes.
While the existing jib-layer-filter-extension-maven is already quite useful, it would be still quite cumbersome to write globs for all direct and transitive dependencies.
For example, think about having some Spring Boot starters in the parent pom for all your microservice, but some other Spring Boot starters are optional and only used by specific microservices. You not only would need quite exact globs for the Spring Boot starters then, but also for their manyfold transitive dependencies.

See also https://github.com/GoogleContainerTools/jib/issues/3036 which is required for this pull request to work.