### PR TITLE
jib-quarkus-extension: Fix build under Windows

### DIFF
--- a/first-party/jib-quarkus-extension-gradle/src/test/java/com/google/cloud/tools/jib/gradle/extension/quarkus/JibQuarkusExtensionTest.java
+++ b/first-party/jib-quarkus-extension-gradle/src/test/java/com/google/cloud/tools/jib/gradle/extension/quarkus/JibQuarkusExtensionTest.java
@@ -30,6 +30,7 @@ import com.google.cloud.tools.jib.gradle.extension.GradleData;
 import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger;
 import com.google.cloud.tools.jib.plugins.extension.JibPluginExtensionException;
 import com.google.common.collect.Sets;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -169,7 +170,8 @@ public class JibQuarkusExtensionTest {
       assertThat(
           ex.getMessage(),
           endsWith(
-              "/my-app-runner.jar doesn't exist; did you run the Qaurkus Gradle plugin "
+              File.separator
+                  + "my-app-runner.jar doesn't exist; did you run the Qaurkus Gradle plugin "
                   + "('quarkusBuild' task)?"));
     }
   }

--- a/first-party/jib-quarkus-extension-maven/src/test/java/com/google/cloud/tools/jib/maven/extension/quarkus/JibQuarkusExtensionTest.java
+++ b/first-party/jib-quarkus-extension-maven/src/test/java/com/google/cloud/tools/jib/maven/extension/quarkus/JibQuarkusExtensionTest.java
@@ -160,7 +160,8 @@ public class JibQuarkusExtensionTest {
       assertThat(
           ex.getMessage(),
           endsWith(
-              "/my-app-runner.jar doesn't exist; did you run the Qaurkus Maven plugin "
+              File.separator
+                  + "my-app-runner.jar doesn't exist; did you run the Qaurkus Maven plugin "
                   + "('compile' and 'quarkus:build' Maven goals)?"));
     }
   }


### PR DESCRIPTION
The tests wrongly assume file separator / which is not true for all platforms.