### PR TITLE
Update layer-filter extension version

### DIFF
--- a/first-party/jib-layer-filter-extension-maven/README.md
+++ b/first-party/jib-layer-filter-extension-maven/README.md
@@ -16,7 +16,7 @@ Check out the [genenal instructions](../../README.md#using-jib-plugin-extensions
     <dependency>
       <groupId>com.google.cloud.tools</groupId>
       <artifactId>jib-layer-filter-extension-maven</artifactId>
-      <version>0.1.0</version>
+      <version>0.2.0</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
We released 0.2.0 last Friday.

https://search.maven.org/artifact/com.google.cloud.tools/jib-layer-filter-extension-maven