### PR TITLE
:memo:  add Javaagent Attachment Plugin Extension to list of third-party extensions

### DIFF
--- a/third-party/README.md
+++ b/third-party/README.md
@@ -8,6 +8,7 @@ Interested in writing an extension? It's easy! Take a look at ["Writing Your Own
 
 - OSGi Bundle Packaging Plugin Extension ([Maven](https://github.com/thought-gang/jib-maven-plugin-extension.git)): an extension to containerize an OSGI bundle (Maven packaging type `bundle`)
 - Layer With Modification Time ([Maven](https://github.com/infobip/jib-layer-with-modification-time-extension-maven)): an extension for selectively setting file timestamps to build time (eg. for hosted web resources)
+- Javaagent Attachment Plugin Extension ([Gradle](https://github.com/ryandens/javaagent-gradle-plugin#jib-integration)): An extension that allows you to automatically add a javaagent from a Maven repository as a layer in your OCI image built by jib and modifies the entrypoint of the image to include the `-javaagent` flag.
 
 - to be added
 - ... 

--- a/third-party/README.md
+++ b/third-party/README.md
@@ -8,7 +8,7 @@ Interested in writing an extension? It's easy! Take a look at ["Writing Your Own
 
 - OSGi Bundle Packaging Plugin Extension ([Maven](https://github.com/thought-gang/jib-maven-plugin-extension.git)): an extension to containerize an OSGI bundle (Maven packaging type `bundle`)
 - Layer With Modification Time ([Maven](https://github.com/infobip/jib-layer-with-modification-time-extension-maven)): an extension for selectively setting file timestamps to build time (eg. for hosted web resources)
-- Javaagent Attachment Plugin Extension ([Gradle](https://github.com/ryandens/javaagent-gradle-plugin#jib-integration)): An extension that allows you to automatically add a javaagent from a Maven repository as a layer in your OCI image built by jib and modifies the entrypoint of the image to include the `-javaagent` flag.
+- Javaagent Attachment Plugin Extension ([Gradle](https://github.com/ryandens/javaagent-gradle-plugin#jib-integration)): An extension that allows you to automatically add a javaagent from a Maven repository as a layer in your container image built by Jib and modifies the entrypoint of the image to include the `-javaagent` flag.
 
 - to be added
 - ... 


### PR DESCRIPTION
I wrote an extension to make it easier to include javaagents in OCI images built by jib, and thought I would share it here! 