### PR TITLE
Enable sonarcloud on jib-extensions

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -51,4 +51,4 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           cd first-party
-          ./gradlew sonarqube -Dsonar.projectKey=GoogleContainerTools_jib-extensions -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=googlecontainertools --stacktrace
+          ./gradlew sonarqube --stacktrace

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -2,7 +2,7 @@ name: SonarCloud Analysis
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Get current date
-        id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
       - uses: actions/checkout@v2
         with:
@@ -40,13 +39,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Test w/ coverage
-        id: install1
         continue-on-error: true
         run: |
           cd first-party
           ./gradlew clean build jacocoTestReport --stacktrace
       - name: Build and analyze
-        id: sonar1
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -51,4 +51,4 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           cd first-party
-          ./gradlew sonarqube --stacktrace
+          ./gradlew sonarqube -Dsonar.projectKey=GoogleContainerTools_jib-extensions -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=googlecontainertools --stacktrace

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -39,7 +39,7 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-      - name: Test w/ coverage # Need this when the directory/pom structure changes
+      - name: Test w/ coverage
         id: install1
         continue-on-error: true
         run: |

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -31,6 +31,7 @@ jobs:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar-${{ steps.date.outputs.date }}
       - uses: actions/cache@v2
+          id: gradle-cache
           with:
             path: |
               ~/.m2/repository
@@ -55,7 +56,7 @@ jobs:
           cd first-party
           ./gradlew \
             sonarqube
-            --define sonar.projectKey=GoogleContainerTools_jib-extensions \
-            --define sonar.host.url=https://sonarcloud.io \
-            --define sonar.organization=googlecontainertools \
+            -Dsonar.projectKey=GoogleContainerTools_jib-extensions \
+            -Dsonar.host.url=https://sonarcloud.io \
+            -Dsonar.organization=googlecontainertools \
             --stacktrace

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Get current date
+        id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
       - uses: actions/checkout@v2
         with:
@@ -50,9 +51,4 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           cd first-party
-          ./gradlew \
-            sonarqube
-            -Dsonar.projectKey=GoogleContainerTools_jib-extensions \
-            -Dsonar.host.url=https://sonarcloud.io \
-            -Dsonar.organization=googlecontainertools \
-            --stacktrace
+          ./gradlew sonarqube --stacktrace

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,61 @@
+name: SonarCloud Analysis
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+  schedule:
+    - cron: '00 6 * * *' # 06:00 UTC every day
+
+jobs:
+  sonar:
+    if: github.repository == 'GoogleContainerTools/jib-extensions' # Only run on upstream branch
+    name: Build with Sonar
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar-${{ steps.date.outputs.date }}
+      - uses: actions/cache@v2
+          with:
+            path: |
+              ~/.m2/repository
+              ~/.gradle/caches
+              ~/.gradle/wrapper
+            key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+            restore-keys: |
+              ${{ runner.os }}-gradle-
+      - name: Test w/ coverage # Need this when the directory/pom structure changes
+        id: install1
+        continue-on-error: true
+        run: |
+          cd first-party
+          ./gradlew clean build jacocoTestReport --stacktrace
+      - name: Build and analyze
+        id: sonar1
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          cd first-party
+          ./gradlew \
+            sonarqube
+            --define sonar.projectKey=GoogleContainerTools_jib-extensions \
+            --define sonar.host.url=https://sonarcloud.io \
+            --define sonar.organization=googlecontainertools \
+            --stacktrace

--- a/first-party/build.gradle
+++ b/first-party/build.gradle
@@ -7,7 +7,7 @@ plugins {
   // apply so we can correctly configure the test runner to be gradle at the project level
   id 'org.jetbrains.gradle.plugin.idea-ext' version '0.10'
 
-  id 'org.sonarqube' version '3.3'
+  id 'org.sonarqube' version '3.3' apply false
 }
 
 // run tests in intellij using gradle test runner
@@ -38,7 +38,6 @@ subprojects {
   apply plugin: 'com.github.sherter.google-java-format'
   apply plugin: 'net.ltgt.errorprone'
   apply plugin: 'jacoco'
-  apply plugin: 'org.sonarqube'
 
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8
@@ -293,15 +292,19 @@ subprojects {
     }
   }
   /* TEST COVERAGE */
-
-  /* SONARQUBE */
-  sonarqube {
-    properties {
-      // properties specified in command line
-    }
-  }
-/* SONARQUBE */
 }
+
+/* SONARQUBE */
+apply plugin: "org.sonarqube"
+sonarqube {
+  properties {
+    property 'sonar.projectName', 'jib-extensions'
+    property 'sonar.projectKey', 'GoogleContainerTools_jib-extensions'
+    property 'sonar.host.url', 'https://sonarcloud.io'
+    property 'sonar.organization', 'googlecontainertools-1'
+  }
+}
+/* SONARQUBE */
 
 /* LOCAL DEVELOPMENT HELPER TASKS */
 tasks.register('dev') {

--- a/first-party/build.gradle
+++ b/first-party/build.gradle
@@ -297,9 +297,7 @@ subprojects {
   /* SONARQUBE */
   sonarqube {
     properties {
-      property 'sonar.projectKey', 'GoogleContainerTools_jib-extensions'
-      property 'sonar.host.url', 'https://sonarcloud.io'
-      property 'sonar.organization', 'googlecontainertools'
+      // properties specified in command line
     }
   }
 /* SONARQUBE */

--- a/first-party/build.gradle
+++ b/first-party/build.gradle
@@ -7,7 +7,8 @@ plugins {
   // apply so we can correctly configure the test runner to be gradle at the project level
   id 'org.jetbrains.gradle.plugin.idea-ext' version '0.10'
 
-  id 'org.sonarqube' version '3.3' apply false
+  // apply so that we can collect quality metrics at the root project level
+  id 'org.sonarqube' version '3.3'
 }
 
 // run tests in intellij using gradle test runner
@@ -295,13 +296,12 @@ subprojects {
 }
 
 /* SONARQUBE */
-apply plugin: "org.sonarqube"
 sonarqube {
   properties {
-    property 'sonar.projectName', 'jib-extensions'
-    property 'sonar.projectKey', 'GoogleContainerTools_jib-extensions'
-    property 'sonar.host.url', 'https://sonarcloud.io'
-    property 'sonar.organization', 'googlecontainertools-1'
+      property 'sonar.projectName', 'jib-extensions'
+      property 'sonar.projectKey', 'GoogleContainerTools_jib-extensions'
+      property 'sonar.host.url', 'https://sonarcloud.io'
+      property 'sonar.organization', 'googlecontainertools-1'
   }
 }
 /* SONARQUBE */

--- a/first-party/build.gradle
+++ b/first-party/build.gradle
@@ -297,10 +297,12 @@ subprojects {
   /* SONARQUBE */
   sonarqube {
     properties {
-      // properties defined in sonarqube command line
+      property 'sonar.projectKey', 'GoogleContainerTools_jib-extensions'
+      property 'sonar.host.url', 'https://sonarcloud.io'
+      property 'sonar.organization', 'googlecontainertools'
     }
   }
-  /* SONARQUBE */
+/* SONARQUBE */
 }
 
 /* LOCAL DEVELOPMENT HELPER TASKS */

--- a/first-party/build.gradle
+++ b/first-party/build.gradle
@@ -7,7 +7,7 @@ plugins {
   // apply so we can correctly configure the test runner to be gradle at the project level
   id 'org.jetbrains.gradle.plugin.idea-ext' version '0.10'
 
-  id 'org.sonarqube' version "3.3"
+  id 'org.sonarqube' version '3.3'
 }
 
 // run tests in intellij using gradle test runner
@@ -297,11 +297,11 @@ subprojects {
   /* SONARQUBE */
   sonarqube {
     properties {
+      // properties defined in sonarqube command line
     }
   }
   /* SONARQUBE */
 }
-
 
 /* LOCAL DEVELOPMENT HELPER TASKS */
 tasks.register('dev') {

--- a/first-party/build.gradle
+++ b/first-party/build.gradle
@@ -6,6 +6,8 @@ plugins {
 
   // apply so we can correctly configure the test runner to be gradle at the project level
   id 'org.jetbrains.gradle.plugin.idea-ext' version '0.10'
+
+  id 'org.sonarqube' version "3.3"
 }
 
 // run tests in intellij using gradle test runner
@@ -36,6 +38,7 @@ subprojects {
   apply plugin: 'com.github.sherter.google-java-format'
   apply plugin: 'net.ltgt.errorprone'
   apply plugin: 'jacoco'
+  apply plugin: 'org.sonarqube'
 
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8
@@ -290,6 +293,13 @@ subprojects {
     }
   }
   /* TEST COVERAGE */
+
+  /* SONARQUBE */
+  sonarqube {
+    properties {
+    }
+  }
+  /* SONARQUBE */
 }
 
 


### PR DESCRIPTION
Sets up sonarcloud on repository, using https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/main/.github/workflows/sonar.yaml as a reference. 

