### PR TITLE
Add private constructor to hide the implicit public one

### DIFF
--- a/first-party/jib-classpath-main-class-extension-gradle/src/main/java/com/google/cloud/tools/jib/gradle/extension/classpathmainclass/JibClasspathMainClassExtractor.java
+++ b/first-party/jib-classpath-main-class-extension-gradle/src/main/java/com/google/cloud/tools/jib/gradle/extension/classpathmainclass/JibClasspathMainClassExtractor.java
@@ -24,6 +24,8 @@ import javax.annotation.Nullable;
 
 public class JibClasspathMainClassExtractor {
 
+  private JibClasspathMainClassExtractor() {}
+
   private static final List<String> classpathOptions =
       Arrays.asList("-cp", "-classpath", "--class-path");
 

--- a/first-party/jib-classpath-main-class-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/classpathmainclass/JibClasspathMainClassExtractor.java
+++ b/first-party/jib-classpath-main-class-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/classpathmainclass/JibClasspathMainClassExtractor.java
@@ -24,6 +24,8 @@ import javax.annotation.Nullable;
 
 public class JibClasspathMainClassExtractor {
 
+  private JibClasspathMainClassExtractor() {}
+
   private static final List<String> classpathOptions =
       Arrays.asList("-cp", "-classpath", "--class-path");
 


### PR DESCRIPTION
Fixes the sonar code [suggestion](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib-extensions&issues=AXrk2c9dAwqlq_z2vpSH&open=AXrk2c9dAwqlq_z2vpSH) to add a private constructor to hide the implicit public one. 