### PR TITLE
Replace containsKey check with computeIfAbsent

### DIFF
--- a/first-party/jib-layer-filter-extension-gradle/src/main/java/com/google/cloud/tools/jib/gradle/extension/layerfilter/JibLayerFilterExtension.java
+++ b/first-party/jib-layer-filter-extension-gradle/src/main/java/com/google/cloud/tools/jib/gradle/extension/layerfilter/JibLayerFilterExtension.java
@@ -127,9 +127,8 @@ public class JibLayerFilterExtension implements JibGradlePluginExtension<Configu
       pathMatchers.put(
           FileSystems.getDefault().getPathMatcher("glob:" + filter.getGlob()), filter.getToLayer());
 
-      if (!newToLayers.containsKey(toLayerName)) {
-        newToLayers.put(toLayerName, FileEntriesLayer.builder().setName(toLayerName));
-      }
+      newToLayers.computeIfAbsent(
+          toLayerName, layerName -> FileEntriesLayer.builder().setName(layerName));
     }
   }
 

--- a/first-party/jib-layer-filter-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/layerfilter/JibLayerFilterExtension.java
+++ b/first-party/jib-layer-filter-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/layerfilter/JibLayerFilterExtension.java
@@ -261,9 +261,8 @@ public class JibLayerFilterExtension implements JibMavenPluginExtension<Configur
       pathMatchers.put(
           FileSystems.getDefault().getPathMatcher("glob:" + filter.getGlob()), filter.getToLayer());
 
-      if (!newToLayers.containsKey(toLayerName)) {
-        newToLayers.put(toLayerName, FileEntriesLayer.builder().setName(toLayerName));
-      }
+      newToLayers.computeIfAbsent(
+          toLayerName, layerName -> FileEntriesLayer.builder().setName(layerName));
     }
   }
 


### PR DESCRIPTION
Fixes sonar [code smell](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib-extensions&issues=AXrk2c89Awqlq_z2vpR_&open=AXrk2c89Awqlq_z2vpR_) to replace use of containsKey with computeIfAbsent. 