### PR TITLE
Use constant instead of String literal

### DIFF
--- a/first-party/jib-native-image-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/nativeimage/JibNativeImageExtension.java
+++ b/first-party/jib-native-image-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/nativeimage/JibNativeImageExtension.java
@@ -56,6 +56,8 @@ public class JibNativeImageExtension implements JibMavenPluginExtension<Void> {
           ValueContainer.CONFIGURATION,
           new String[] {"container", "entrypoint"});
 
+  private static final String MAIN_CLASS = "mainClass";
+
   // If <imageName> is not specified, then native-image uses the mainClass name as the executable.
   // If <mainClass> is not specified, then native-image-maven-plugin looks at the configurations
   // for a set of other well-known plugins.
@@ -71,19 +73,19 @@ public class JibNativeImageExtension implements JibMavenPluginExtension<Void> {
           new ConfigValueLocation(
               "org.graalvm.nativeimage:native-image-maven-plugin",
               ValueContainer.CONFIGURATION,
-              new String[] {"mainClass"}),
+              new String[] {MAIN_CLASS}),
           new ConfigValueLocation(
               "org.apache.maven.plugins:maven-shade-plugin",
               ValueContainer.EXECUTIONS,
-              new String[] {"transformers", "transformer", "mainClass"}),
+              new String[] {"transformers", "transformer", MAIN_CLASS}),
           new ConfigValueLocation(
               "org.apache.maven.plugins:maven-assembly-plugin",
               ValueContainer.CONFIGURATION,
-              new String[] {"archive", "manifest", "mainClass"}),
+              new String[] {"archive", "manifest", MAIN_CLASS}),
           new ConfigValueLocation(
               "org.apache.maven.plugins:maven-jar-plugin",
               ValueContainer.CONFIGURATION,
-              new String[] {"archive", "manifest", "mainClass"}));
+              new String[] {"archive", "manifest", MAIN_CLASS}));
 
   @Override
   public Optional<Class<Void>> getExtraConfigType() {


### PR DESCRIPTION
Fixes sonar [suggestion](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib-extensions&issues=AXrk8c29EdI53Ssr7Fn0&open=AXrk8c29EdI53Ssr7Fn0) to use a constant instead of String literal 