### PR TITLE
Use IllegalArgumentException instead of RuntimeException in JibNativeImageExtension

### DIFF
--- a/first-party/jib-native-image-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/nativeimage/JibNativeImageExtension.java
+++ b/first-party/jib-native-image-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/nativeimage/JibNativeImageExtension.java
@@ -189,7 +189,7 @@ public class JibNativeImageExtension implements JibMavenPluginExtension<Void> {
             .findFirst();
 
       default:
-        throw new RuntimeException("unknown enum value: " + location.valueContainer);
+        throw new IllegalArgumentException("unknown enum value: " + location.valueContainer);
     }
   }
 


### PR DESCRIPTION
Resolves [this](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib-extensions&issues=AXrk8c29EdI53Ssr7Fnw&open=AXrk8c29EdI53Ssr7Fnw) sonar item. 