### PR TITLE
Move createParentDependencyLayers into config

### DIFF
--- a/first-party/jib-layer-filter-extension-maven/README.md
+++ b/first-party/jib-layer-filter-extension-maven/README.md
@@ -51,9 +51,9 @@ Check out the [genenal instructions](../../README.md#using-jib-plugin-extensions
               <toLayer>this layer will not be created</toLayer>
             </filter>
           </filters>
+          <!-- To create separate layers for parent dependencies-->
+          <createParentDependencyLayers>true</createParentDependencyLayers>
         </configuration>
-        <!-- To create separate layers for parent dependencies-->
-        <createParentDependencyLayers>true</createParentDependencyLayers>
       </pluginExtension>
     </pluginExtensions>
   </configuration>


### PR DESCRIPTION
Fix README.md for JibLayerFilterExtension:
`createParentDependencyLayers` belongs into the `configuration` element