### PR TITLE
Fix previously built module "leaking" file entries into subsequent build

### DIFF
--- a/first-party/jib-layer-filter-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/layerfilter/JibLayerFilterExtension.java
+++ b/first-party/jib-layer-filter-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/layerfilter/JibLayerFilterExtension.java
@@ -239,7 +239,7 @@ public class JibLayerFilterExtension implements JibMavenPluginExtension<Configur
     List<String> originalLayerNames =
         buildPlan.getLayers().stream().map(LayerObject::getName).collect(Collectors.toList());
 
-    newToLayers.clear();  //ensure empty (in case previously built module already populated it)
+    newToLayers.clear(); // ensure empty (in case previously built module already populated it)
     for (Configuration.Filter filter : config.getFilters()) {
       String toLayerName = filter.getToLayer();
       if (!toLayerName.isEmpty() && originalLayerNames.contains(toLayerName)) {

--- a/first-party/jib-layer-filter-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/layerfilter/JibLayerFilterExtension.java
+++ b/first-party/jib-layer-filter-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/layerfilter/JibLayerFilterExtension.java
@@ -239,6 +239,7 @@ public class JibLayerFilterExtension implements JibMavenPluginExtension<Configur
     List<String> originalLayerNames =
         buildPlan.getLayers().stream().map(LayerObject::getName).collect(Collectors.toList());
 
+    newToLayers.clear();  //ensure empty (in case previously built module already populated it)
     for (Configuration.Filter filter : config.getFilters()) {
       String toLayerName = filter.getToLayer();
       if (!toLayerName.isEmpty() && originalLayerNames.contains(toLayerName)) {

--- a/first-party/jib-layer-filter-extension-maven/src/test/java/com/google/cloud/tools/jib/maven/extension/layerfilter/JibLayerFilterExtensionTest.java
+++ b/first-party/jib-layer-filter-extension-maven/src/test/java/com/google/cloud/tools/jib/maven/extension/layerfilter/JibLayerFilterExtensionTest.java
@@ -24,7 +24,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.cloud.tools.jib.api.buildplan.*;
+import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
+import com.google.cloud.tools.jib.api.buildplan.ContainerBuildPlan;
+import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
+import com.google.cloud.tools.jib.api.buildplan.LayerObject;
 import com.google.cloud.tools.jib.maven.extension.MavenData;
 import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger;
 import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger.LogLevel;

--- a/first-party/jib-layer-filter-extension-maven/src/test/java/com/google/cloud/tools/jib/maven/extension/layerfilter/JibLayerFilterExtensionTest.java
+++ b/first-party/jib-layer-filter-extension-maven/src/test/java/com/google/cloud/tools/jib/maven/extension/layerfilter/JibLayerFilterExtensionTest.java
@@ -24,10 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
-import com.google.cloud.tools.jib.api.buildplan.ContainerBuildPlan;
-import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
-import com.google.cloud.tools.jib.api.buildplan.LayerObject;
+import com.google.cloud.tools.jib.api.buildplan.*;
 import com.google.cloud.tools.jib.maven.extension.MavenData;
 import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger;
 import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger.LogLevel;
@@ -475,5 +472,56 @@ public class JibLayerFilterExtensionTest {
     verify(logger)
         .log(LogLevel.INFO, "Potential matches: parent-lib-different-version-2.0.0-whatever.jar");
     verify(logger).log(LogLevel.INFO, "Dependency from parent not found: parentlibfilteredpath");
+  }
+
+  @Test
+  public void testExtendContainerBuildPlan_multipleModulesBuild()
+      throws JibPluginExtensionException {
+    JibLayerFilterExtension filterExtension =
+        new JibLayerFilterExtension(); // same instance used twice
+
+    Configuration.Filter filterFoo = mockFilter("**/foo/**", "foo");
+    Configuration.Filter filterBar = mockFilter("**/bar/**", "bar");
+    when(config.getFilters()).thenReturn(Arrays.asList(filterFoo, filterBar));
+
+    ContainerBuildPlan buildPlanM1 =
+        ContainerBuildPlan.builder()
+            .addLayer(buildLayer("m1l1", Arrays.asList("/m1/foo/a")))
+            .addLayer(buildLayer("m1l2", Arrays.asList("/m1/foo/b", "/m1/bar/c")))
+            .build();
+
+    ContainerBuildPlan newPlanM1 =
+        filterExtension.extendContainerBuildPlan(
+            buildPlanM1, null, Optional.of(config), null, logger);
+
+    assertEquals(2, newPlanM1.getLayers().size());
+    FileEntriesLayer newLayer1M1 = (FileEntriesLayer) newPlanM1.getLayers().get(0);
+    FileEntriesLayer newLayer2M1 = (FileEntriesLayer) newPlanM1.getLayers().get(1);
+    assertEquals("foo", newLayer1M1.getName());
+    assertEquals("bar", newLayer2M1.getName());
+    assertEquals(
+        buildLayer("", Arrays.asList("/m1/foo/a", "/m1/foo/b")).getEntries(),
+        newLayer1M1.getEntries());
+    assertEquals(buildLayer("", Arrays.asList("/m1/bar/c")).getEntries(), newLayer2M1.getEntries());
+
+    ContainerBuildPlan buildPlanM2 =
+        ContainerBuildPlan.builder()
+            .addLayer(buildLayer("m2l1", Arrays.asList("/m2/foo/a", "/m2/bar/b")))
+            .addLayer(buildLayer("m2l2", Arrays.asList("/m2/foo/c")))
+            .build();
+
+    ContainerBuildPlan newPlanM2 =
+        filterExtension.extendContainerBuildPlan(
+            buildPlanM2, null, Optional.of(config), null, logger);
+
+    assertEquals(2, newPlanM1.getLayers().size());
+    FileEntriesLayer newLayer1M2 = (FileEntriesLayer) newPlanM2.getLayers().get(0);
+    FileEntriesLayer newLayer2M2 = (FileEntriesLayer) newPlanM2.getLayers().get(1);
+    assertEquals("foo", newLayer1M2.getName());
+    assertEquals("bar", newLayer2M2.getName());
+    assertEquals(
+        buildLayer("", Arrays.asList("/m2/foo/a", "/m2/foo/c")).getEntries(),
+        newLayer1M2.getEntries());
+    assertEquals(buildLayer("", Arrays.asList("/m2/bar/b")).getEntries(), newLayer2M2.getEntries());
   }
 }


### PR DESCRIPTION
I'm creating just PR without opening separate issue so I'll explain the issue here.

Consider having maven multi-module project:
```
parent/
   shared-lib/  (skip docker build)
   service-a/   (build image)
   service-b/   (build image)
```
Various layer filters are defined on `parent` so that both `service-a` and `service-b` inherit configuration.
Now, when doing maven reactor build in order: `shared-lib`, `service-a`, `service-b`
Final result is that:
 - `service-a` is build as expected, every filter did it's job and resources are sliced to layers as expected
 - `service-b` has everything that it should have **+** everything that `service-a` had in it's corresponding layers.
   + that happens because build planned file entries of `service-a` got *"leaked"* via [JibLayerFilterExtension.newToLayers](https://github.com/GoogleContainerTools/jib-extensions/blob/v0.2.0-jib-layer-filter-extension-maven/first-party/jib-layer-filter-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/layerfilter/JibLayerFilterExtension.java#L62) into subsequent module build of `service-b`
   
I'm not sure if this "leakage" is legit/desired in any scenario, if the answer is yes, then I would consider adding some configuration property (`boolean`) for this extension and then do clearing conditionally.
```java
if (config.isClearFilteredLayers()) {  //better name
   newToLayers.clear();
}
```
