### PR TITLE
Gradle: Fix prev built module "leaking" files into subsequent build

### DIFF
--- a/first-party/jib-layer-filter-extension-gradle/src/main/java/com/google/cloud/tools/jib/gradle/extension/layerfilter/JibLayerFilterExtension.java
+++ b/first-party/jib-layer-filter-extension-gradle/src/main/java/com/google/cloud/tools/jib/gradle/extension/layerfilter/JibLayerFilterExtension.java
@@ -108,6 +108,7 @@ public class JibLayerFilterExtension implements JibGradlePluginExtension<Configu
     List<String> originalLayerNames =
         buildPlan.getLayers().stream().map(LayerObject::getName).collect(Collectors.toList());
 
+    newToLayers.clear(); // ensure empty (in case previously built module already populated it)
     for (Configuration.Filter filter : config.getFilters()) {
       String toLayerName = filter.getToLayer();
       if (!toLayerName.isEmpty() && originalLayerNames.contains(toLayerName)) {

--- a/first-party/jib-layer-filter-extension-gradle/src/test/java/com/google/cloud/tools/jib/gradle/extension/layerfilter/JibLayerFilterExtensionTest.java
+++ b/first-party/jib-layer-filter-extension-gradle/src/test/java/com/google/cloud/tools/jib/gradle/extension/layerfilter/JibLayerFilterExtensionTest.java
@@ -289,4 +289,55 @@ public class JibLayerFilterExtensionTest {
         Arrays.asList("/alpha/Bob", "/beta/Bob", "/gamma/Bob"), layerToExtractionPaths(newLayer5));
     assertEquals(Arrays.asList("/gamma/Charlie"), layerToExtractionPaths(newLayer6));
   }
+
+  @Test
+  public void testExtendContainerBuildPlan_multipleModulesBuild()
+          throws JibPluginExtensionException {
+    JibLayerFilterExtension filterExtension =
+            new JibLayerFilterExtension(); // same instance used twice
+
+    Configuration.Filter filterFoo = mockFilter("**/foo/**", "foo");
+    Configuration.Filter filterBar = mockFilter("**/bar/**", "bar");
+    when(config.getFilters()).thenReturn(Arrays.asList(filterFoo, filterBar));
+
+    ContainerBuildPlan buildPlanM1 =
+            ContainerBuildPlan.builder()
+                    .addLayer(buildLayer("m1l1", Arrays.asList("/m1/foo/a")))
+                    .addLayer(buildLayer("m1l2", Arrays.asList("/m1/foo/b", "/m1/bar/c")))
+                    .build();
+
+    ContainerBuildPlan newPlanM1 =
+            filterExtension.extendContainerBuildPlan(
+                    buildPlanM1, null, Optional.of(config), null, logger);
+
+    assertEquals(2, newPlanM1.getLayers().size());
+    FileEntriesLayer newLayer1M1 = (FileEntriesLayer) newPlanM1.getLayers().get(0);
+    FileEntriesLayer newLayer2M1 = (FileEntriesLayer) newPlanM1.getLayers().get(1);
+    assertEquals("foo", newLayer1M1.getName());
+    assertEquals("bar", newLayer2M1.getName());
+    assertEquals(
+            buildLayer("", Arrays.asList("/m1/foo/a", "/m1/foo/b")).getEntries(),
+            newLayer1M1.getEntries());
+    assertEquals(buildLayer("", Arrays.asList("/m1/bar/c")).getEntries(), newLayer2M1.getEntries());
+
+    ContainerBuildPlan buildPlanM2 =
+            ContainerBuildPlan.builder()
+                    .addLayer(buildLayer("m2l1", Arrays.asList("/m2/foo/a", "/m2/bar/b")))
+                    .addLayer(buildLayer("m2l2", Arrays.asList("/m2/foo/c")))
+                    .build();
+
+    ContainerBuildPlan newPlanM2 =
+            filterExtension.extendContainerBuildPlan(
+                    buildPlanM2, null, Optional.of(config), null, logger);
+
+    assertEquals(2, newPlanM1.getLayers().size());
+    FileEntriesLayer newLayer1M2 = (FileEntriesLayer) newPlanM2.getLayers().get(0);
+    FileEntriesLayer newLayer2M2 = (FileEntriesLayer) newPlanM2.getLayers().get(1);
+    assertEquals("foo", newLayer1M2.getName());
+    assertEquals("bar", newLayer2M2.getName());
+    assertEquals(
+            buildLayer("", Arrays.asList("/m2/foo/a", "/m2/foo/c")).getEntries(),
+            newLayer1M2.getEntries());
+    assertEquals(buildLayer("", Arrays.asList("/m2/bar/b")).getEntries(), newLayer2M2.getEntries());
+  }
 }

--- a/first-party/jib-layer-filter-extension-gradle/src/test/java/com/google/cloud/tools/jib/gradle/extension/layerfilter/JibLayerFilterExtensionTest.java
+++ b/first-party/jib-layer-filter-extension-gradle/src/test/java/com/google/cloud/tools/jib/gradle/extension/layerfilter/JibLayerFilterExtensionTest.java
@@ -292,23 +292,23 @@ public class JibLayerFilterExtensionTest {
 
   @Test
   public void testExtendContainerBuildPlan_multipleModulesBuild()
-          throws JibPluginExtensionException {
+      throws JibPluginExtensionException {
     JibLayerFilterExtension filterExtension =
-            new JibLayerFilterExtension(); // same instance used twice
+        new JibLayerFilterExtension(); // same instance used twice
 
     Configuration.Filter filterFoo = mockFilter("**/foo/**", "foo");
     Configuration.Filter filterBar = mockFilter("**/bar/**", "bar");
     when(config.getFilters()).thenReturn(Arrays.asList(filterFoo, filterBar));
 
     ContainerBuildPlan buildPlanM1 =
-            ContainerBuildPlan.builder()
-                    .addLayer(buildLayer("m1l1", Arrays.asList("/m1/foo/a")))
-                    .addLayer(buildLayer("m1l2", Arrays.asList("/m1/foo/b", "/m1/bar/c")))
-                    .build();
+        ContainerBuildPlan.builder()
+            .addLayer(buildLayer("m1l1", Arrays.asList("/m1/foo/a")))
+            .addLayer(buildLayer("m1l2", Arrays.asList("/m1/foo/b", "/m1/bar/c")))
+            .build();
 
     ContainerBuildPlan newPlanM1 =
-            filterExtension.extendContainerBuildPlan(
-                    buildPlanM1, null, Optional.of(config), null, logger);
+        filterExtension.extendContainerBuildPlan(
+            buildPlanM1, null, Optional.of(config), null, logger);
 
     assertEquals(2, newPlanM1.getLayers().size());
     FileEntriesLayer newLayer1M1 = (FileEntriesLayer) newPlanM1.getLayers().get(0);
@@ -316,19 +316,19 @@ public class JibLayerFilterExtensionTest {
     assertEquals("foo", newLayer1M1.getName());
     assertEquals("bar", newLayer2M1.getName());
     assertEquals(
-            buildLayer("", Arrays.asList("/m1/foo/a", "/m1/foo/b")).getEntries(),
-            newLayer1M1.getEntries());
+        buildLayer("", Arrays.asList("/m1/foo/a", "/m1/foo/b")).getEntries(),
+        newLayer1M1.getEntries());
     assertEquals(buildLayer("", Arrays.asList("/m1/bar/c")).getEntries(), newLayer2M1.getEntries());
 
     ContainerBuildPlan buildPlanM2 =
-            ContainerBuildPlan.builder()
-                    .addLayer(buildLayer("m2l1", Arrays.asList("/m2/foo/a", "/m2/bar/b")))
-                    .addLayer(buildLayer("m2l2", Arrays.asList("/m2/foo/c")))
-                    .build();
+        ContainerBuildPlan.builder()
+            .addLayer(buildLayer("m2l1", Arrays.asList("/m2/foo/a", "/m2/bar/b")))
+            .addLayer(buildLayer("m2l2", Arrays.asList("/m2/foo/c")))
+            .build();
 
     ContainerBuildPlan newPlanM2 =
-            filterExtension.extendContainerBuildPlan(
-                    buildPlanM2, null, Optional.of(config), null, logger);
+        filterExtension.extendContainerBuildPlan(
+            buildPlanM2, null, Optional.of(config), null, logger);
 
     assertEquals(2, newPlanM1.getLayers().size());
     FileEntriesLayer newLayer1M2 = (FileEntriesLayer) newPlanM2.getLayers().get(0);
@@ -336,8 +336,8 @@ public class JibLayerFilterExtensionTest {
     assertEquals("foo", newLayer1M2.getName());
     assertEquals("bar", newLayer2M2.getName());
     assertEquals(
-            buildLayer("", Arrays.asList("/m2/foo/a", "/m2/foo/c")).getEntries(),
-            newLayer1M2.getEntries());
+        buildLayer("", Arrays.asList("/m2/foo/a", "/m2/foo/c")).getEntries(),
+        newLayer1M2.getEntries());
     assertEquals(buildLayer("", Arrays.asList("/m2/bar/b")).getEntries(), newLayer2M2.getEntries());
   }
 }


### PR DESCRIPTION
Same as #119 but for `jib-layer-filter-extension-gradle`