### PR TITLE
Fix Quarkus typo in exceptions

### DIFF
--- a/first-party/jib-quarkus-extension-gradle/src/main/java/com/google/cloud/tools/jib/gradle/extension/quarkus/JibQuarkusExtension.java
+++ b/first-party/jib-quarkus-extension-gradle/src/main/java/com/google/cloud/tools/jib/gradle/extension/quarkus/JibQuarkusExtension.java
@@ -77,7 +77,7 @@ public class JibQuarkusExtension implements JibGradlePluginExtension<Void> {
       if (!Files.isRegularFile(jar)) {
         throw new JibPluginExtensionException(
             getClass(),
-            jar + " doesn't exist; did you run the Qaurkus Gradle plugin ('quarkusBuild' task)?");
+            jar + " doesn't exist; did you run the Quarkus Gradle plugin ('quarkusBuild' task)?");
       }
 
       ContainerBuildPlan.Builder planBuilder = buildPlan.toBuilder();

--- a/first-party/jib-quarkus-extension-gradle/src/test/java/com/google/cloud/tools/jib/gradle/extension/quarkus/JibQuarkusExtensionTest.java
+++ b/first-party/jib-quarkus-extension-gradle/src/test/java/com/google/cloud/tools/jib/gradle/extension/quarkus/JibQuarkusExtensionTest.java
@@ -169,7 +169,7 @@ public class JibQuarkusExtensionTest {
           ex.getMessage(),
           endsWith(
               File.separator
-                  + "my-app-runner.jar doesn't exist; did you run the Qaurkus Gradle plugin "
+                  + "my-app-runner.jar doesn't exist; did you run the Quarkus Gradle plugin "
                   + "('quarkusBuild' task)?"));
     }
   }

--- a/first-party/jib-quarkus-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/quarkus/JibQuarkusExtension.java
+++ b/first-party/jib-quarkus-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/quarkus/JibQuarkusExtension.java
@@ -79,7 +79,7 @@ public class JibQuarkusExtension implements JibMavenPluginExtension<Void> {
         throw new JibPluginExtensionException(
             getClass(),
             jar
-                + " doesn't exist; did you run the Qaurkus Maven plugin "
+                + " doesn't exist; did you run the Quarkus Maven plugin "
                 + "('compile' and 'quarkus:build' Maven goals)?");
       }
 

--- a/first-party/jib-quarkus-extension-maven/src/test/java/com/google/cloud/tools/jib/maven/extension/quarkus/JibQuarkusExtensionTest.java
+++ b/first-party/jib-quarkus-extension-maven/src/test/java/com/google/cloud/tools/jib/maven/extension/quarkus/JibQuarkusExtensionTest.java
@@ -159,7 +159,7 @@ public class JibQuarkusExtensionTest {
           ex.getMessage(),
           endsWith(
               File.separator
-                  + "my-app-runner.jar doesn't exist; did you run the Qaurkus Maven plugin "
+                  + "my-app-runner.jar doesn't exist; did you run the Quarkus Maven plugin "
                   + "('compile' and 'quarkus:build' Maven goals)?"));
     }
   }


### PR DESCRIPTION
Hi!
In some exceptions, there was a typo: it said `Qaurkus` instead of `Quarkus`. This simple pull request fixes that. I have also corrected the corresponding unit tests.