### PR TITLE
Update README with instructions for Quarkus fast-jar support

### DIFF
--- a/first-party/jib-quarkus-extension-gradle/README.md
+++ b/first-party/jib-quarkus-extension-gradle/README.md
@@ -4,13 +4,17 @@
 
 Enables containerizing a Quarkus app built with [Quarkus Gradle Plugin](https://plugins.gradle.org/plugin/io.quarkus).
 
-The Quarkus app framework prepares a special "runner" JAR and aguments dependency JARs, where the standard Jib containerization does not fit. This extension takes the JARs prepared by Quakus (runner JAR and augmented dependency JARs) and sets the entrypoint to run the runner JAR.
+The Quarkus app framework has two different package types:
+* legacy-jar: original Quarkus "runner" JAR
+* fast-jar: default Quarkus package type since [1.12](https://quarkus.io/blog/quarkus-1-12-0-final-released/)
+
+You can use either package type with Jib Quarkus extension by configuring the `pluginExtensions.pluginExtension.properties`. Default value is the legacy-jar, but can be easily changed to fast-jar.
 
 ## Examples
 
-Check out the [genenal instructions](../../README.md#using-jib-plugin-extensions) for applying a Jib plugin extension.
+Check out the [general instructions](../../README.md#using-jib-plugin-extensions) for applying a Jib plugin extension.
 
-Note that `container.mainClass` should be set to some placeholder value to suppress Jib warning about missing main class.
+Note that `container.mainClass` should be set to some placeholder value to suppress Jib warning about missing main class. Package type has two valid values: `fast-jar` and `legacy-jar`.
 
 ```gradle
 // should be at the top of build.gradle
@@ -34,6 +38,7 @@ jib {
   pluginExtensions {
     pluginExtension {
       implementation = 'com.google.cloud.tools.jib.gradle.extension.quarkus.JibQuarkusExtension'
+      properties = [packageType: 'fast-jar'] // to use Quarkus fast-jar package type
     }
   }
 }
@@ -41,7 +46,7 @@ jib {
 
 ## Standard Jib Configurations 
 
-By the way Quarkus needs to run (via `java -jar quarkus-runner.jar`), some standard Jib configruations will have no effect:
+By the way Quarkus needs to run (via `java -jar quarkus-runner.jar` or `java -jar quarkus-app/quarkus-run.jar`), some standard Jib configurations will have no effect:
 
 - `container.mainClass`
 - `container.entrypoint` (Note `container.args` continues to work.)


### PR DESCRIPTION
As discussed in  #129 this is the PR with documentation updates that show the possibility of using the fast-jar package type.