### PR TITLE
Add fast-jar support for Quarkus Maven plugin

### DIFF
--- a/first-party/jib-quarkus-extension-maven/README.md
+++ b/first-party/jib-quarkus-extension-maven/README.md
@@ -4,13 +4,18 @@
 
 Enables containerizing a Quarkus app built with [Quarkus Maven Plugin](https://search.maven.org/artifact/io.quarkus/quarkus-maven-plugin).
 
-The Quarkus app framework prepares a special "runner" JAR and augments dependency JARs, where the standard Jib containerization does not fit. This extension takes the JARs prepared by Quarkus (runner JAR and augmented dependency JARs) and sets the entrypoint to run the runner JAR.
+The Quarkus app framework has two different package types:
+* legacy-jar: original Quarkus "runner" JAR
+* fast-jar: default Quarkus package type since [1.12](https://quarkus.io/blog/quarkus-1-12-0-final-released/)
+
+You can use either package type with Jib Quarkus extension by configuring the `<pluginExtensions><pluginExtension><properties>`. Default value is the legacy-jar, but can be easily changed to fast-jar.
+
 
 ## Examples
 
 Check out the [general instructions](../../README.md#using-jib-plugin-extensions) for applying a Jib plugin extension.
 
-Note that `<container><mainClass>` should be set to some placeholder value to suppress Jib warning about missing main class.
+Note that `<container><mainClass>` should be set to some placeholder value to suppress Jib warning about missing main class. Package type has two valid values: `fast-jar` and `legacy-jar`.
 
 ```xml
 <plugin>
@@ -43,7 +48,10 @@ Note that `<container><mainClass>` should be set to some placeholder value to su
     ...
     <pluginExtensions>
       <pluginExtension>
-        <implementation>com.google.cloud.tools.jib.maven.extension.quarkus.JibQuarkusExtension</implementation>
+          <implementation>com.google.cloud.tools.jib.maven.extension.quarkus.JibQuarkusExtension</implementation>
+          <properties>
+              <packageType>fast-jar</packageType> <!-- to use Quarkus fast-jar package type -->
+          </properties>
       </pluginExtension>
     </pluginExtensions>
   </configuration>
@@ -52,7 +60,7 @@ Note that `<container><mainClass>` should be set to some placeholder value to su
 
 ## Standard Jib Configurations Being Ignored
 
-By the way Quarkus needs to run (via `java -jar quarkus-runner.jar`), some standard Jib configurations will have no effect:
+By the way Quarkus needs to run (via `java -jar quarkus-runner.jar` or `java -jar quarkus-app/quarkus-run.jar`), some standard Jib configurations will have no effect:
 
 - `<container><mainClass>`
 - `<container><entrypoint>` (Note `<container><args>` continues to work.)

--- a/first-party/jib-quarkus-extension-maven/README.md
+++ b/first-party/jib-quarkus-extension-maven/README.md
@@ -4,11 +4,11 @@
 
 Enables containerizing a Quarkus app built with [Quarkus Maven Plugin](https://search.maven.org/artifact/io.quarkus/quarkus-maven-plugin).
 
-The Quarkus app framework prepares a special "runner" JAR and aguments dependency JARs, where the standard Jib containerization does not fit. This extension takes the JARs prepared by Quakus (runner JAR and augmented dependency JARs) and sets the entrypoint to run the runner JAR.
+The Quarkus app framework prepares a special "runner" JAR and augments dependency JARs, where the standard Jib containerization does not fit. This extension takes the JARs prepared by Quarkus (runner JAR and augmented dependency JARs) and sets the entrypoint to run the runner JAR.
 
 ## Examples
 
-Check out the [genenal instructions](../../README.md#using-jib-plugin-extensions) for applying a Jib plugin extension.
+Check out the [general instructions](../../README.md#using-jib-plugin-extensions) for applying a Jib plugin extension.
 
 Note that `<container><mainClass>` should be set to some placeholder value to suppress Jib warning about missing main class.
 
@@ -52,7 +52,7 @@ Note that `<container><mainClass>` should be set to some placeholder value to su
 
 ## Standard Jib Configurations Being Ignored
 
-By the way Quarkus needs to run (via `java -jar quarkus-runner.jar`), some standard Jib configruations will have no effect:
+By the way Quarkus needs to run (via `java -jar quarkus-runner.jar`), some standard Jib configurations will have no effect:
 
 - `<container><mainClass>`
 - `<container><entrypoint>` (Note `<container><args>` continues to work.)

--- a/first-party/jib-quarkus-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/quarkus/JibQuarkusExtension.java
+++ b/first-party/jib-quarkus-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/quarkus/JibQuarkusExtension.java
@@ -80,7 +80,6 @@ public class JibQuarkusExtension implements JibMavenPluginExtension<Void> {
 
       readJibConfigurations(mavenData.getMavenProject());
 
-      logger.log(LogLevel.ERROR, "Package type: " + packageType);
       Path jar = jarResolver.getPathToLocalJar(mavenData.getMavenProject());
 
       ContainerBuildPlan.Builder planBuilder = buildPlan.toBuilder();

--- a/first-party/jib-quarkus-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/quarkus/JibQuarkusExtension.java
+++ b/first-party/jib-quarkus-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/quarkus/JibQuarkusExtension.java
@@ -22,6 +22,9 @@ import com.google.cloud.tools.jib.api.buildplan.ContainerBuildPlan;
 import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
 import com.google.cloud.tools.jib.maven.extension.JibMavenPluginExtension;
 import com.google.cloud.tools.jib.maven.extension.MavenData;
+import com.google.cloud.tools.jib.maven.extension.quarkus.resolvers.JarResolver;
+import com.google.cloud.tools.jib.maven.extension.quarkus.resolvers.JarResolverFactory;
+import com.google.cloud.tools.jib.maven.extension.quarkus.resolvers.impl.LegacyJarResolver;
 import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger;
 import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger.LogLevel;
 import com.google.cloud.tools.jib.plugins.extension.JibPluginExtensionException;
@@ -44,7 +47,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.model.Build;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
@@ -53,6 +55,9 @@ public class JibQuarkusExtension implements JibMavenPluginExtension<Void> {
 
   private AbsoluteUnixPath appRoot = AbsoluteUnixPath.get("/app");
   private List<String> jvmFlags = Collections.emptyList();
+
+  private JarResolver jarResolver = new LegacyJarResolver();
+  private PackageType packageType = PackageType.LEGACY;
 
   @Override
   public Optional<Class<Void>> getExtraConfigType() {
@@ -69,28 +74,26 @@ public class JibQuarkusExtension implements JibMavenPluginExtension<Void> {
       throws JibPluginExtensionException {
     try {
       logger.log(LogLevel.LIFECYCLE, "Running Quarkus Jib extension");
+
+      packageType =
+          PackageType.getPackageTypeByName(properties.getOrDefault("packageType", "legacy-jar"));
+
       readJibConfigurations(mavenData.getMavenProject());
 
-      Build build = mavenData.getMavenProject().getBuild();
-      Path outputDirectory = Paths.get(build.getDirectory());
-      Path jar = outputDirectory.resolve(build.getFinalName() + "-runner.jar");
-
-      if (!Files.isRegularFile(jar)) {
-        throw new JibPluginExtensionException(
-            getClass(),
-            jar
-                + " doesn't exist; did you run the Quarkus Maven plugin "
-                + "('compile' and 'quarkus:build' Maven goals)?");
-      }
+      logger.log(LogLevel.ERROR, "Package type: " + packageType);
+      Path jar = jarResolver.getPathToLocalJar(mavenData.getMavenProject());
 
       ContainerBuildPlan.Builder planBuilder = buildPlan.toBuilder();
       planBuilder.setLayers(Collections.emptyList());
 
-      // dependency layers
-      addDependencyLayers(mavenData.getMavenSession(), planBuilder, outputDirectory.resolve("lib"));
+      // Dependency layers
+      for (Path path : jarResolver.getPathsToDependencies(mavenData.getMavenProject())) {
+        addDependencyLayers(
+            mavenData.getMavenProject(), mavenData.getMavenSession(), planBuilder, path);
+      }
 
       // Quarkus runner JAR layer
-      AbsoluteUnixPath appRootJar = appRoot.resolve("app.jar");
+      AbsoluteUnixPath appRootJar = jarResolver.getPathToJarInContainer(appRoot);
       FileEntriesLayer jarLayer =
           FileEntriesLayer.builder().setName("quarkus jar").addEntry(jar, appRootJar).build();
       planBuilder.addLayer(jarLayer);
@@ -117,7 +120,10 @@ public class JibQuarkusExtension implements JibMavenPluginExtension<Void> {
   }
 
   private void addDependencyLayers(
-      MavenSession session, ContainerBuildPlan.Builder planBuilder, Path libDirectory)
+      MavenProject project,
+      MavenSession session,
+      ContainerBuildPlan.Builder planBuilder,
+      Path libDirectory)
       throws IOException {
     // Collect all artifact files involved in this Maven session.
     Set<String> projectArtifactFilenames =
@@ -138,25 +144,35 @@ public class JibQuarkusExtension implements JibMavenPluginExtension<Void> {
             path.getFileName().toString().contains("SNAPSHOT") && !isProjectDependency.test(path);
     Predicate<Path> isThirdParty = isProjectDependency.negate().and(isSnapshot.negate());
 
-    addDependencyLayer(planBuilder, libDirectory, "dependencies", isThirdParty);
-    addDependencyLayer(planBuilder, libDirectory, "snapshot dependencies", isSnapshot);
-    addDependencyLayer(planBuilder, libDirectory, "project dependencies", isProjectDependency);
+    addDependencyLayer(project, planBuilder, libDirectory, "dependencies", isThirdParty);
+    addDependencyLayer(project, planBuilder, libDirectory, "snapshot dependencies", isSnapshot);
+    addDependencyLayer(
+        project, planBuilder, libDirectory, "project dependencies", isProjectDependency);
   }
 
   private void addDependencyLayer(
+      MavenProject project,
       ContainerBuildPlan.Builder planBuilder,
       Path libDirectory,
       String layerName,
       Predicate<Path> predicate)
       throws IOException {
     FileEntriesLayer.Builder layerBuilder = FileEntriesLayer.builder().setName(layerName);
+
+    String relativePathInLib =
+        Paths.get(project.getBuild().getDirectory())
+            .toUri()
+            .relativize(libDirectory.toUri())
+            .toString();
+
     try (Stream<Path> files = Files.list(libDirectory)) {
       files
           .filter(predicate)
           .forEach(
               path -> {
                 layerBuilder.addEntry(
-                    path, appRoot.resolve("lib").resolve(path.getFileName().toString()));
+                    path,
+                    appRoot.resolve(relativePathInLib).resolve(path.getFileName().toString()));
               });
     }
 
@@ -170,6 +186,7 @@ public class JibQuarkusExtension implements JibMavenPluginExtension<Void> {
   private void readJibConfigurations(MavenProject project) {
     Plugin jibPlugin = project.getPlugin("com.google.cloud.tools:jib-maven-plugin");
     if (jibPlugin != null) {
+      jarResolver = new JarResolverFactory().getJarResolver(packageType);
       Xpp3Dom configurationDom = (Xpp3Dom) jibPlugin.getConfiguration();
       if (configurationDom != null) {
         Xpp3Dom containerDom = configurationDom.getChild("container");

--- a/first-party/jib-quarkus-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/quarkus/PackageType.java
+++ b/first-party/jib-quarkus-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/quarkus/PackageType.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.maven.extension.quarkus;
+
+import com.google.cloud.tools.jib.plugins.extension.JibPluginExtensionException;
+import java.util.Arrays;
+import java.util.Optional;
+
+public enum PackageType {
+  LEGACY("legacy-jar"),
+  FAST("fast-jar");
+
+  private final String packageType;
+
+  PackageType(String packageType) {
+    this.packageType = packageType;
+  }
+
+  /**
+   * Retrieves package type by the config property value.
+   *
+   * @param packageType name of the package type
+   * @return enum of the package type
+   * @throws JibPluginExtensionException if there is an unknown package type value given to the
+   *     extension config
+   */
+  public static PackageType getPackageTypeByName(String packageType)
+      throws JibPluginExtensionException {
+    Optional<PackageType> packageTypeEnum =
+        Arrays.stream(values()).filter(el -> packageType.equals(el.packageType)).findFirst();
+    if (packageTypeEnum.isPresent()) {
+      return packageTypeEnum.get();
+    }
+    throw new JibPluginExtensionException(
+        JibQuarkusExtension.class, "Unknown packageType, possible values: legacy-jar, fast-jar");
+  }
+}

--- a/first-party/jib-quarkus-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/quarkus/PackageType.java
+++ b/first-party/jib-quarkus-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/quarkus/PackageType.java
@@ -24,24 +24,23 @@ public enum PackageType {
   LEGACY("legacy-jar"),
   FAST("fast-jar");
 
-  private final String packageType;
+  private final String name;
 
-  PackageType(String packageType) {
-    this.packageType = packageType;
+  PackageType(String name) {
+    this.name = name;
   }
 
   /**
    * Retrieves package type by the config property value.
    *
-   * @param packageType name of the package type
+   * @param name name of the package type
    * @return enum of the package type
    * @throws JibPluginExtensionException if there is an unknown package type value given to the
    *     extension config
    */
-  public static PackageType getPackageTypeByName(String packageType)
-      throws JibPluginExtensionException {
+  public static PackageType getPackageTypeByName(String name) throws JibPluginExtensionException {
     Optional<PackageType> packageTypeEnum =
-        Arrays.stream(values()).filter(el -> packageType.equals(el.packageType)).findFirst();
+        Arrays.stream(values()).filter(el -> name.equals(el.name)).findFirst();
     if (packageTypeEnum.isPresent()) {
       return packageTypeEnum.get();
     }

--- a/first-party/jib-quarkus-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/quarkus/resolvers/JarResolver.java
+++ b/first-party/jib-quarkus-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/quarkus/resolvers/JarResolver.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.maven.extension.quarkus.resolvers;
+
+import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
+import com.google.cloud.tools.jib.plugins.extension.JibPluginExtensionException;
+import java.nio.file.Path;
+import java.util.List;
+import org.apache.maven.project.MavenProject;
+
+public interface JarResolver {
+
+  /**
+   * Retrieves path to Jar in local environment.
+   *
+   * @param project Maven project for which this extension is run
+   * @return path to jar in build directory
+   * @throws JibPluginExtensionException if there is no jar
+   */
+  Path getPathToLocalJar(MavenProject project) throws JibPluginExtensionException;
+
+  /**
+   * Retrieves a list of dependencies that need to be packed together with jar.
+   *
+   * @param project Maven project for which this extension is run
+   * @return list of paths to dependencies
+   */
+  List<Path> getPathsToDependencies(MavenProject project);
+
+  /**
+   * Retrieves a path where jar will be located in the container.
+   *
+   * @param appRoot path root where application will reside in container
+   * @return path to jar in the container
+   */
+  AbsoluteUnixPath getPathToJarInContainer(AbsoluteUnixPath appRoot);
+}

--- a/first-party/jib-quarkus-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/quarkus/resolvers/JarResolverFactory.java
+++ b/first-party/jib-quarkus-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/quarkus/resolvers/JarResolverFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.maven.extension.quarkus.resolvers;
+
+import com.google.cloud.tools.jib.maven.extension.quarkus.PackageType;
+import com.google.cloud.tools.jib.maven.extension.quarkus.resolvers.impl.FastJarResolver;
+import com.google.cloud.tools.jib.maven.extension.quarkus.resolvers.impl.LegacyJarResolver;
+
+public class JarResolverFactory {
+
+  /**
+   * Factory that returns a correct jar resolver depending on given package type.
+   *
+   * @param packageType package type of Quarkus application
+   * @return jar resolver for given package type
+   */
+  public JarResolver getJarResolver(PackageType packageType) {
+    switch (packageType) {
+      case LEGACY:
+        return new LegacyJarResolver();
+      case FAST:
+        return new FastJarResolver();
+      default:
+        throw new IllegalArgumentException(
+            "Quarkus packaging is set wrong! It has to be either legacy or fast.");
+    }
+  }
+}

--- a/first-party/jib-quarkus-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/quarkus/resolvers/JarResolverFactory.java
+++ b/first-party/jib-quarkus-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/quarkus/resolvers/JarResolverFactory.java
@@ -36,7 +36,7 @@ public class JarResolverFactory {
         return new FastJarResolver();
       default:
         throw new IllegalArgumentException(
-            "Quarkus packaging is set wrong! It has to be either legacy or fast.");
+            "Unable to determine the packaging type. Please ensure that it is either legacy-jar or fast-jar.");
     }
   }
 }

--- a/first-party/jib-quarkus-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/quarkus/resolvers/impl/FastJarResolver.java
+++ b/first-party/jib-quarkus-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/quarkus/resolvers/impl/FastJarResolver.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.maven.extension.quarkus.resolvers.impl;
+
+import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
+import com.google.cloud.tools.jib.maven.extension.quarkus.JibQuarkusExtension;
+import com.google.cloud.tools.jib.maven.extension.quarkus.resolvers.JarResolver;
+import com.google.cloud.tools.jib.plugins.extension.JibPluginExtensionException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.maven.project.MavenProject;
+
+public class FastJarResolver implements JarResolver {
+
+  private static final String FAST_JAR_LOCATION = "quarkus-app/quarkus-run.jar";
+
+  @Override
+  public Path getPathToLocalJar(MavenProject project) throws JibPluginExtensionException {
+
+    Path buildDir = Paths.get(project.getBuild().getDirectory());
+    Path jar = buildDir.resolve(FAST_JAR_LOCATION);
+
+    if (!Files.isRegularFile(jar)) {
+      throw new JibPluginExtensionException(
+          JibQuarkusExtension.class,
+          "quarkus-app/quarkus-run.jar doesn't exist; did you run the Quarkus Maven plugin "
+              + "('compile' and 'quarkus:build' Maven goals)?");
+    }
+
+    return jar;
+  }
+
+  @Override
+  public List<Path> getPathsToDependencies(MavenProject project) {
+    Path outputPath = Paths.get(project.getBuild().getDirectory());
+    return Arrays.asList(
+        outputPath.resolve("quarkus-app/lib/main"),
+        outputPath.resolve("quarkus-app/lib/boot"),
+        outputPath.resolve("quarkus-app/app"),
+        outputPath.resolve("quarkus-app/quarkus"));
+  }
+
+  @Override
+  public AbsoluteUnixPath getPathToJarInContainer(AbsoluteUnixPath appRoot) {
+    return appRoot.resolve(FAST_JAR_LOCATION);
+  }
+}

--- a/first-party/jib-quarkus-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/quarkus/resolvers/impl/LegacyJarResolver.java
+++ b/first-party/jib-quarkus-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/quarkus/resolvers/impl/LegacyJarResolver.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.maven.extension.quarkus.resolvers.impl;
+
+import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
+import com.google.cloud.tools.jib.maven.extension.quarkus.JibQuarkusExtension;
+import com.google.cloud.tools.jib.maven.extension.quarkus.resolvers.JarResolver;
+import com.google.cloud.tools.jib.plugins.extension.JibPluginExtensionException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import org.apache.maven.model.Build;
+import org.apache.maven.project.MavenProject;
+
+public class LegacyJarResolver implements JarResolver {
+
+  @Override
+  public Path getPathToLocalJar(MavenProject project) throws JibPluginExtensionException {
+    Build build = project.getBuild();
+    Path outputDirectory = Paths.get(build.getDirectory());
+    Path jar = outputDirectory.resolve(build.getFinalName() + "-runner.jar");
+
+    if (!Files.isRegularFile(jar)) {
+      throw new JibPluginExtensionException(
+          JibQuarkusExtension.class,
+          jar
+              + " doesn't exist; did you run the Quarkus Maven plugin "
+              + "('compile' and 'quarkus:build' Maven goals)?");
+    }
+    return jar;
+  }
+
+  @Override
+  public List<Path> getPathsToDependencies(MavenProject project) {
+    return Collections.singletonList(Paths.get(project.getBuild().getDirectory()).resolve("lib"));
+  }
+
+  @Override
+  public AbsoluteUnixPath getPathToJarInContainer(AbsoluteUnixPath appRoot) {
+    return appRoot.resolve("app.jar");
+  }
+}

--- a/first-party/jib-quarkus-extension-maven/src/test/java/com/google/cloud/tools/jib/maven/extension/quarkus/JibQuarkusExtensionTest.java
+++ b/first-party/jib-quarkus-extension-maven/src/test/java/com/google/cloud/tools/jib/maven/extension/quarkus/JibQuarkusExtensionTest.java
@@ -34,7 +34,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.maven.artifact.Artifact;
@@ -73,6 +76,8 @@ public class JibQuarkusExtensionTest {
   @Mock private Build mavenBuild;
   @Mock private Plugin jibPlugin;
 
+  private final Map<String, String> properties = new HashMap<>();
+
   private static FileEntriesLayer buildLayer(String layerName, List<String> filePaths) {
     FileEntriesLayer.Builder builder = FileEntriesLayer.builder().setName(layerName);
     for (String path : filePaths) {
@@ -89,12 +94,7 @@ public class JibQuarkusExtensionTest {
 
   @Before
   public void setUp() throws IOException {
-    Path outputDir = tempFolder.newFolder("target").toPath();
-    Path quarkusLibDir = Files.createDirectory(outputDir.resolve("lib"));
-    Files.createFile(outputDir.resolve("my-app-runner.jar"));
-    Files.createFile(quarkusLibDir.resolve("com.example.sub-module-artifact.jar"));
-    Files.createFile(quarkusLibDir.resolve("com.example.third-party-artifact.jar"));
-    Files.createFile(quarkusLibDir.resolve("com.example.third-party-SNAPSHOT-artifact.jar"));
+    when(mavenBuild.getDirectory()).thenReturn("");
 
     when(mavenData.getMavenProject()).thenReturn(jibModule);
     when(mavenData.getMavenSession()).thenReturn(mavenSession);
@@ -109,7 +109,6 @@ public class JibQuarkusExtensionTest {
 
     when(jibModule.getBuild()).thenReturn(mavenBuild);
     when(mavenBuild.getFinalName()).thenReturn("my-app");
-    when(mavenBuild.getDirectory()).thenReturn(outputDir.toString());
 
     Xpp3Dom jibConfigurationDom = new Xpp3Dom("configuration");
     Xpp3Dom containerDom = new Xpp3Dom("container");
@@ -133,11 +132,13 @@ public class JibQuarkusExtensionTest {
   }
 
   @Test
-  public void testExtendContainerBuildPlan_entrypoint() throws JibPluginExtensionException {
+  public void testExtendContainerBuildPlan_entrypoint()
+      throws JibPluginExtensionException, IOException {
+    createLegacyJar();
     ContainerBuildPlan buildPlan = ContainerBuildPlan.builder().build();
     ContainerBuildPlan newPlan =
         new JibQuarkusExtension()
-            .extendContainerBuildPlan(buildPlan, null, Optional.empty(), mavenData, logger);
+            .extendContainerBuildPlan(buildPlan, properties, Optional.empty(), mavenData, logger);
 
     assertEquals(
         Arrays.asList("java", "-verbose:gc", "-Dmy.property=value", "-jar", "/new/appRoot/app.jar"),
@@ -146,12 +147,13 @@ public class JibQuarkusExtensionTest {
 
   @Test
   public void testExtendContainerBuildPlan_noQuarkusRunnerJar() throws IOException {
+    createLegacyJar();
     Files.delete(tempFolder.getRoot().toPath().resolve("target").resolve("my-app-runner.jar"));
     ContainerBuildPlan buildPlan = ContainerBuildPlan.builder().build();
 
     try {
       new JibQuarkusExtension()
-          .extendContainerBuildPlan(buildPlan, null, Optional.empty(), mavenData, logger);
+          .extendContainerBuildPlan(buildPlan, properties, Optional.empty(), mavenData, logger);
       fail();
     } catch (JibPluginExtensionException ex) {
       assertEquals(JibQuarkusExtension.class, ex.getExtensionClass());
@@ -165,7 +167,45 @@ public class JibQuarkusExtensionTest {
   }
 
   @Test
-  public void testExtendContainerBuildPlan_layers() throws JibPluginExtensionException {
+  public void testExtendContainerBuildPlan_packageTypeConfig()
+      throws IOException, JibPluginExtensionException {
+    createFastJar();
+    properties.put("packageType", "fast-jar");
+    ContainerBuildPlan buildPlan = ContainerBuildPlan.builder().build();
+
+    ContainerBuildPlan newPlan =
+        new JibQuarkusExtension()
+            .extendContainerBuildPlan(buildPlan, properties, Optional.empty(), mavenData, logger);
+    assertEquals(7, newPlan.getLayers().size());
+    FileEntriesLayer lastLayer = (FileEntriesLayer) newPlan.getLayers().get(6);
+    assertEquals(
+        Collections.singletonList("/new/appRoot/quarkus-app/quarkus-run.jar"),
+        layerToExtractionPaths(lastLayer));
+  }
+
+  @Test
+  public void testExtendContainerBuildPlan_noQuarkusFastJar() throws IOException {
+    ContainerBuildPlan buildPlan = ContainerBuildPlan.builder().build();
+    properties.put("packageType", "fast-jar");
+
+    try {
+      new JibQuarkusExtension()
+          .extendContainerBuildPlan(buildPlan, properties, Optional.empty(), mavenData, logger);
+      fail();
+    } catch (JibPluginExtensionException ex) {
+      assertEquals(JibQuarkusExtension.class, ex.getExtensionClass());
+      assertThat(
+          ex.getMessage(),
+          endsWith(
+              "quarkus-app/quarkus-run.jar doesn't exist; did you run the Quarkus Maven plugin "
+                  + "('compile' and 'quarkus:build' Maven goals)?"));
+    }
+  }
+
+  @Test
+  public void testExtendContainerBuildPlan_LegacyJarLayers()
+      throws JibPluginExtensionException, IOException {
+    createLegacyJar();
     FileEntriesLayer originalLayer = buildLayer("to be reset", Arrays.asList("/ignored"));
     FileEntriesLayer extraLayer1 = buildLayer("extra files", Arrays.asList("/extra/files/1"));
     FileEntriesLayer extraLayer2 = buildLayer("extra files", Arrays.asList("/extra/files/2"));
@@ -176,7 +216,7 @@ public class JibQuarkusExtensionTest {
 
     ContainerBuildPlan newPlan =
         new JibQuarkusExtension()
-            .extendContainerBuildPlan(buildPlan, null, Optional.empty(), mavenData, logger);
+            .extendContainerBuildPlan(buildPlan, properties, Optional.empty(), mavenData, logger);
 
     assertEquals(6, newPlan.getLayers().size());
     FileEntriesLayer layer1 = (FileEntriesLayer) newPlan.getLayers().get(0);
@@ -205,5 +245,105 @@ public class JibQuarkusExtensionTest {
     assertEquals(Arrays.asList("/new/appRoot/app.jar"), layerToExtractionPaths(layer4));
     assertEquals(extraLayer1.getEntries(), layer5.getEntries());
     assertEquals(extraLayer2.getEntries(), layer6.getEntries());
+  }
+
+  @Test
+  public void testExtendContainerBuildPlan_FastJarLayers()
+      throws JibPluginExtensionException, IOException {
+    createFastJar();
+    FileEntriesLayer originalLayer = buildLayer("to be reset", Arrays.asList("/ignored"));
+    FileEntriesLayer extraLayer1 = buildLayer("extra files", Arrays.asList("/extra/files/1"));
+    FileEntriesLayer extraLayer2 = buildLayer("extra files", Arrays.asList("/extra/files/2"));
+    ContainerBuildPlan buildPlan =
+        ContainerBuildPlan.builder()
+            .setLayers(Arrays.asList(originalLayer, extraLayer1, extraLayer2))
+            .build();
+    properties.put("packageType", "fast-jar");
+
+    ContainerBuildPlan newPlan =
+        new JibQuarkusExtension()
+            .extendContainerBuildPlan(buildPlan, properties, Optional.empty(), mavenData, logger);
+
+    assertEquals(9, newPlan.getLayers().size());
+    FileEntriesLayer layer1 = (FileEntriesLayer) newPlan.getLayers().get(0);
+    FileEntriesLayer layer2 = (FileEntriesLayer) newPlan.getLayers().get(1);
+    FileEntriesLayer layer3 = (FileEntriesLayer) newPlan.getLayers().get(2);
+    FileEntriesLayer layer4 = (FileEntriesLayer) newPlan.getLayers().get(3);
+    FileEntriesLayer layer5 = (FileEntriesLayer) newPlan.getLayers().get(4);
+    FileEntriesLayer layer6 = (FileEntriesLayer) newPlan.getLayers().get(5);
+    FileEntriesLayer layer7 = (FileEntriesLayer) newPlan.getLayers().get(6);
+    FileEntriesLayer layer8 = (FileEntriesLayer) newPlan.getLayers().get(7);
+    FileEntriesLayer layer9 = (FileEntriesLayer) newPlan.getLayers().get(8);
+
+    assertEquals("dependencies", layer1.getName());
+    assertEquals("snapshot dependencies", layer2.getName());
+    assertEquals("project dependencies", layer3.getName());
+    assertEquals("dependencies", layer4.getName());
+    assertEquals("snapshot dependencies", layer5.getName());
+    assertEquals("dependencies", layer6.getName());
+    assertEquals("quarkus jar", layer7.getName());
+    assertEquals("extra files", layer8.getName());
+    assertEquals("extra files", layer9.getName());
+
+    assertEquals(
+        Collections.singletonList(
+            "/new/appRoot/quarkus-app/lib/main/com.example.third-party-artifact.jar"),
+        layerToExtractionPaths(layer1));
+    assertEquals(
+        Collections.singletonList(
+            "/new/appRoot/quarkus-app/lib/main/com.example.third-party-SNAPSHOT-artifact.jar"),
+        layerToExtractionPaths(layer2));
+    assertEquals(
+        Collections.singletonList(
+            "/new/appRoot/quarkus-app/lib/main/com.example.sub-module-artifact.jar"),
+        layerToExtractionPaths(layer3));
+    assertEquals(
+        Collections.singletonList(
+            "/new/appRoot/quarkus-app/lib/boot/io.quarkus.quarkus-bootstrap-runner.jar"),
+        layerToExtractionPaths(layer4));
+    assertEquals(
+        Collections.singletonList("/new/appRoot/quarkus-app/app/my-app-runner-SNAPSHOT.jar"),
+        layerToExtractionPaths(layer5));
+    assertEquals(
+        Collections.singletonList("/new/appRoot/quarkus-app/quarkus/generated-bytecode.jar"),
+        layerToExtractionPaths(layer6));
+    assertEquals(
+        Collections.singletonList("/new/appRoot/quarkus-app/quarkus-run.jar"),
+        layerToExtractionPaths(layer7));
+    assertEquals(extraLayer1.getEntries(), layer8.getEntries());
+    assertEquals(extraLayer2.getEntries(), layer9.getEntries());
+  }
+
+  private void createLegacyJar() throws IOException {
+    Path buildDir = tempFolder.newFolder("target").toPath();
+    Path quarkusLibDir = Files.createDirectory(buildDir.resolve("lib"));
+    Files.createFile(buildDir.resolve("my-app-runner.jar"));
+    Files.createFile(quarkusLibDir.resolve("com.example.sub-module-artifact.jar"));
+    Files.createFile(quarkusLibDir.resolve("com.example.third-party-artifact.jar"));
+    Files.createFile(quarkusLibDir.resolve("com.example.third-party-SNAPSHOT-artifact.jar"));
+
+    when(mavenData.getMavenProject().getBuild().getDirectory()).thenReturn(buildDir.toString());
+    when(mavenBuild.getDirectory()).thenReturn(buildDir.toString());
+  }
+
+  private void createFastJar() throws IOException {
+    Path buildDir = tempFolder.newFolder("target").toPath();
+    Path quarkusAppDir = Files.createDirectory(buildDir.resolve("quarkus-app"));
+    Path quarkusLibDir = Files.createDirectory(quarkusAppDir.resolve("lib"));
+    Path quarkusLibBootDir = Files.createDirectory(quarkusLibDir.resolve("boot"));
+    Path quarkusLibMainDir = Files.createDirectory(quarkusLibDir.resolve("main"));
+    Path quarkusAppLibDir = Files.createDirectory(quarkusAppDir.resolve("app"));
+    Path quarkusQuarkusDir = Files.createDirectory(quarkusAppDir.resolve("quarkus"));
+
+    Files.createFile(quarkusAppDir.resolve("quarkus-run.jar"));
+    Files.createFile(quarkusLibBootDir.resolve("io.quarkus.quarkus-bootstrap-runner.jar"));
+    Files.createFile(quarkusLibMainDir.resolve("com.example.sub-module-artifact.jar"));
+    Files.createFile(quarkusLibMainDir.resolve("com.example.third-party-artifact.jar"));
+    Files.createFile(quarkusLibMainDir.resolve("com.example.third-party-SNAPSHOT-artifact.jar"));
+    Files.createFile(quarkusAppLibDir.resolve("my-app-runner-SNAPSHOT.jar"));
+    Files.createFile(quarkusQuarkusDir.resolve("generated-bytecode.jar"));
+
+    when(mavenData.getMavenProject().getBuild().getDirectory()).thenReturn(buildDir.toString());
+    when(mavenBuild.getDirectory()).thenReturn(buildDir.toString());
   }
 }


### PR DESCRIPTION
This resolves the issue #92. 
Similar was done in #129 for Gradle plugin, but this is for the Maven plugin. Most of the code is therefore more or less the same.

Sidenote: when will be a new release of the aforementioned Gradle Quarkus plugin?