### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
+        run: echo "date=$(date +'%Y-%m-%d' --utc)" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis


### PR DESCRIPTION
Thank you for your interest in contributing! For general guidelines, please refer to
the [contributing guide](https://github.com/GoogleContainerTools/jib-extensions/blob/master/CONTRIBUTING.md).

Before submitting a pull request, please make sure to:

- [x] Identify an existing [issue](https://github.com/GoogleContainerTools/jib-extensions/issues) to associate
  with your proposed change, or [file a new issue](https://github.com/GoogleContainerTools/jib-extensions/issues/new).
- [x] Describe any implementation plans in the issue and wait for a review from the repository maintainers.

Fixes #154  🛠️

Update `.github/workflows/sonar.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
```

**TO-BE**

```yml
run: echo "date=$(date +'%Y-%m-%d' --utc)" >> $GITHUB_OUTPUT
```