### PR TITLE
chore: update jib-core version to 0.24.0 and plugins version to 3.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The following example adds and runs the [Jib Layer-Filter Extension](first-party
   <plugin>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>jib-maven-plugin</artifactId>
-    <version>3.3.1</version>
+    <version>3.3.2</version>
 
     <!-- 1. have extension classes available on Jib's runtime classpath -->
     <dependencies>
@@ -65,7 +65,7 @@ The following example adds and runs the [Jib Layer-Filter Extension](first-party
 
 When properly configured and loaded, Jib outputs the loaded extensions in the log. When you configure multiple `<pluginExtension>`s, Jib runs the extensions in the given order.
 ```
-[INFO] --- jib-maven-plugin:3.3.1:build (default-cli) @ helloworld ---
+[INFO] --- jib-maven-plugin:3.3.2:build (default-cli) @ helloworld ---
 [INFO] Running extension: com.google.cloud.tools.jib.maven.extension.layerfilter.JibLayerFilterExtension
 ```
 

--- a/first-party/build.gradle
+++ b/first-party/build.gradle
@@ -52,8 +52,8 @@ subprojects {
     GUAVA: 'com.google.guava:guava:30.1.1-jre',
     JSR305: 'com.google.code.findbugs:jsr305:3.0.2', // transitively pulled in by GUAVA
 
-    JIB_CORE: 'com.google.cloud.tools:jib-core:0.23.0',
-    JIB_GRADLE: 'com.google.cloud.tools:jib-gradle-plugin:3.3.1',
+    JIB_CORE: 'com.google.cloud.tools:jib-core:0.24.0',
+    JIB_GRADLE: 'com.google.cloud.tools:jib-gradle-plugin:3.3.2',
 
     // for Build Plan and Jib Plugins Extension API
     JIB_GRADLE_EXTENSION: 'com.google.cloud.tools:jib-gradle-plugin-extension-api:0.4.0',

--- a/first-party/jib-layer-filter-extension-maven/README.md
+++ b/first-party/jib-layer-filter-extension-maven/README.md
@@ -10,7 +10,7 @@ Check out the [genenal instructions](../../README.md#using-jib-plugin-extensions
 <plugin>
   <groupId>com.google.cloud.tools</groupId>
   <artifactId>jib-maven-plugin</artifactId>
-  <version>3.3.1</version>
+  <version>3.3.2</version>
 
   <dependencies>
     <dependency>

--- a/first-party/jib-native-image-extension-maven/README.md
+++ b/first-party/jib-native-image-extension-maven/README.md
@@ -14,7 +14,7 @@ Check out the [genenal instructions](../../README.md#using-jib-plugin-extensions
 <plugin>
   <groupId>com.google.cloud.tools</groupId>
   <artifactId>jib-maven-plugin</artifactId>
-  <version>3.3.1</version>
+  <version>3.3.2</version>
 
   <dependencies>
     <dependency>

--- a/first-party/jib-ownership-extension-maven/README.md
+++ b/first-party/jib-ownership-extension-maven/README.md
@@ -12,7 +12,7 @@ Check out the [genenal instructions](../../README.md#using-jib-plugin-extensions
 <plugin>
   <groupId>com.google.cloud.tools</groupId>
   <artifactId>jib-maven-plugin</artifactId>
-  <version>3.3.1</version>
+  <version>3.3.2</version>
 
   <dependencies>
     <dependency>

--- a/first-party/jib-quarkus-extension-maven/README.md
+++ b/first-party/jib-quarkus-extension-maven/README.md
@@ -21,7 +21,7 @@ Note that `<container><mainClass>` should be set to some placeholder value to su
 <plugin>
   <groupId>com.google.cloud.tools</groupId>
   <artifactId>jib-maven-plugin</artifactId>
-  <version>3.3.1</version>
+  <version>3.3.2</version>
 
   <dependencies>
     <dependency>

--- a/first-party/jib-spring-boot-extension-maven/README.md
+++ b/first-party/jib-spring-boot-extension-maven/README.md
@@ -16,7 +16,7 @@ Check out the [genenal instructions](../../README.md#using-jib-plugin-extensions
 <plugin>
   <groupId>com.google.cloud.tools</groupId>
   <artifactId>jib-maven-plugin</artifactId>
-  <version>3.3.1</version>
+  <version>3.3.2</version>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
To be merged after other post-release action items are complete in [Jib](https://github.com/GoogleContainerTools/jib).