### PR TITLE
Exclude docker compose

### DIFF
--- a/first-party/build.gradle
+++ b/first-party/build.gradle
@@ -59,7 +59,7 @@ subprojects {
     JIB_GRADLE_EXTENSION: 'com.google.cloud.tools:jib-gradle-plugin-extension-api:0.4.0',
     JIB_MAVEN_EXTENSION: 'com.google.cloud.tools:jib-maven-plugin-extension-api:0.4.0',
 
-    SPRING_BOOT: 'org.springframework.boot:spring-boot-gradle-plugin:2.3.1.RELEASE', // for Spring Boot Gradle extension
+    SPRING_BOOT: 'org.springframework.boot:spring-boot-gradle-plugin:2.4.0', // for Spring Boot Gradle extension
     MAVEN_API: 'org.apache.maven:maven-plugin-api:3.8.2',
 
     //test

--- a/first-party/build.gradle
+++ b/first-party/build.gradle
@@ -59,7 +59,7 @@ subprojects {
     JIB_GRADLE_EXTENSION: 'com.google.cloud.tools:jib-gradle-plugin-extension-api:0.4.0',
     JIB_MAVEN_EXTENSION: 'com.google.cloud.tools:jib-maven-plugin-extension-api:0.4.0',
 
-    SPRING_BOOT: 'org.springframework.boot:spring-boot-gradle-plugin:2.4.0', // for Spring Boot Gradle extension
+    SPRING_BOOT: 'org.springframework.boot:spring-boot-gradle-plugin:2.3.1.RELEASE', // for Spring Boot Gradle extension
     MAVEN_API: 'org.apache.maven:maven-plugin-api:3.8.2',
 
     //test

--- a/first-party/jib-spring-boot-extension-maven/README.md
+++ b/first-party/jib-spring-boot-extension-maven/README.md
@@ -2,9 +2,9 @@
 
 Provides extra support for Spring Boot applications. As of now, this extension provides the following functionalities:
 
-- Including and excluding `spring-boot-devtools`
+- Including and excluding `spring-boot-devtools` and / or `spring-boot-docker-compose`
 
-   Handles the [Spring Boot developer tools issue](https://github.com/GoogleContainerTools/jib/issues/2336) that Jib always (correctly) packages the [`spring-boot-devtools`](https://docs.spring.io/spring-boot/docs/current/reference/html/using-spring-boot.html#using-boot-devtools) dependency. Applying this extension makes Jib include or exclude the dependency in the same way Spring Boot does for their repackaged fat JAR. For example, Spring Boot by default excludes `spring-boot-devtools` from the repackaged JAR, so the extension by default excludes it from an image too. On the other hand, if you set `<excludeDevtools>false` in Spring Boot, the extension does nothing (keeps the dependency in the image).
+   Handles the [Spring Boot issue](https://github.com/GoogleContainerTools/jib/issues/2336) that Jib always (correctly) packages [optional dependencies](https://docs.spring.io/spring-boot/docs/current/reference/html/using-spring-boot.html#using-boot-devtools). Applying this extension makes Jib include or exclude these dependencies in the same way Spring Boot does for their repackaged fat JAR. For example, Spring Boot by default excludes `spring-boot-devtools` and `spring-boot-docker-compose` from the repackaged JAR, so the extension by default excludes them from an image too. On the other hand, if you set `<excludeDevtools>false` or `<excludeDockerCompose>false` in Spring Boot, the extension keeps those dependencies in the image.
 
    Note that one can still properly and correctly resolve this "issue" without this extension, for example, by setting up two Maven profiles, as explained in the issue link above.
 
@@ -22,7 +22,7 @@ Check out the [genenal instructions](../../README.md#using-jib-plugin-extensions
     <dependency>
       <groupId>com.google.cloud.tools</groupId>
       <artifactId>jib-spring-boot-extension-maven</artifactId>
-      <version>0.1.0</version>
+      <version>0.5.0</version>
     </dependency>
   </dependencies>
 
@@ -30,7 +30,10 @@ Check out the [genenal instructions](../../README.md#using-jib-plugin-extensions
     ...
     <pluginExtensions>
       <pluginExtension>
-        <implementation>com.google.cloud.tools.jib.maven.extension.springboot.JibSpringBootExtension</implementation>
+        <implementation>com.google.cloud.tools.jib.maven.extension.springboot.JibSpringBootDevtoolsExtension</implementation>
+      </pluginExtension>
+      <pluginExtension>
+        <implementation>com.google.cloud.tools.jib.maven.extension.springboot.JibSpringBootDockerComposeExtension</implementation>
       </pluginExtension>
     </pluginExtensions>
   </configuration>

--- a/first-party/jib-spring-boot-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/springboot/JibSpringBootDevtoolsExtension.java
+++ b/first-party/jib-spring-boot-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/springboot/JibSpringBootDevtoolsExtension.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.maven.extension.springboot;
+
+public class JibSpringBootDevtoolsExtension implements JibSpringBootModuleExtension {
+
+  @Override
+  public String getModuleName() {
+    return "spring-boot-devtools";
+  }
+
+  @Override
+  public String getExcludePropertyName() {
+    return "excludeDevtools";
+  }
+}

--- a/first-party/jib-spring-boot-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/springboot/JibSpringBootDockerComposeExtension.java
+++ b/first-party/jib-spring-boot-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/springboot/JibSpringBootDockerComposeExtension.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.maven.extension.springboot;
+
+public class JibSpringBootDockerComposeExtension implements JibSpringBootModuleExtension {
+
+  @Override
+  public String getModuleName() {
+    return "spring-boot-docker-compose";
+  }
+
+  @Override
+  public String getExcludePropertyName() {
+    return "excludeDockerCompose";
+  }
+}

--- a/first-party/jib-spring-boot-extension-maven/src/main/resources/META-INF/services/com.google.cloud.tools.jib.maven.extension.JibMavenPluginExtension
+++ b/first-party/jib-spring-boot-extension-maven/src/main/resources/META-INF/services/com.google.cloud.tools.jib.maven.extension.JibMavenPluginExtension
@@ -1,1 +1,1 @@
-com.google.cloud.tools.jib.maven.extension.springboot.JibSpringBootExtension
+com.google.cloud.tools.jib.maven.extension.springboot.JibSpringBootDevtoolsExtension


### PR DESCRIPTION
I added some code to the Maven extension to enable excluding both Devtools and Docker-Compose Spring Boot modules.
Due to renaming the default extension, a major version upgrade is necessary.

The Gradle extension does not need any modification since it already excludes developmentOnly dependencies by default.

Fixes #158🛠️