### PR TITLE
doc: fixes #165

### DIFF
--- a/first-party/jib-layer-filter-extension-maven/README.md
+++ b/first-party/jib-layer-filter-extension-maven/README.md
@@ -51,9 +51,9 @@ Check out the [genenal instructions](../../README.md#using-jib-plugin-extensions
               <toLayer>this layer will not be created</toLayer>
             </filter>
           </filters>
+          <!-- To create separate layers for parent dependencies-->
+          <createParentDependencyLayers>true</createParentDependencyLayers>
         </configuration>
-        <!-- To create separate layers for parent dependencies-->
-        <createParentDependencyLayers>true</createParentDependencyLayers>
       </pluginExtension>
     </pluginExtensions>
   </configuration>


### PR DESCRIPTION
according to [javadoc](https://github.com/GoogleContainerTools/jib-extensions/blob/9876eadca9c18d4b61fa9340215d85e9b0de64af/first-party/jib-layer-filter-extension-maven/src/main/java/com/google/cloud/tools/jib/maven/extension/layerfilter/Configuration.java#L39) on  Configuration class, `createParentDependencyLayers` should be inside configuration section.

fixes #165 