### PR TITLE
Add JVM Flags extension to list of third-party extensions

### DIFF
--- a/third-party/README.md
+++ b/third-party/README.md
@@ -10,6 +10,7 @@ Interested in writing an extension? It's easy! Take a look at ["Writing Your Own
 - Layer With Modification Time ([Maven](https://github.com/infobip/jib-layer-with-modification-time-extension-maven)): an extension for selectively setting file timestamps to build time (eg. for hosted web resources)
 - OSGi Bundle Packaging Plugin Extension ([Maven](https://github.com/thought-gang/jib-maven-plugin-extension.git)): an extension to containerize an OSGI bundle (Maven packaging type `bundle`)
 - Javaagent Attachment Plugin Extension ([Gradle](https://github.com/ryandens/javaagent-gradle-plugin#jib-integration)): An extension that allows you to automatically add a javaagent from a Maven repository as a layer in your container image built by Jib and modifies the entrypoint of the image to include the `-javaagent` flag.
+- JVM Flags Extension ([Maven](https://github.com/softleader/jib-jvm-flags-extension-maven)): An extension that outputs the configured `jvmFlags` into the `/app/jib-jvm-flags-file` file. This allows a custom entrypoint to access these flags, such as using a shell script to launch the app.
 
 - to be added
 - ... 


### PR DESCRIPTION
I wrote an extension that allows custom entrypoints to access configured `jvmFlags`, providing flexibility for scenarios such as using a shell script to launch the application. I thought it would be helpful to share it here!