### PR TITLE
chore: Update JIB Gradle plugin version to 3.5.3

### DIFF
--- a/first-party/build.gradle
+++ b/first-party/build.gradle
@@ -63,7 +63,7 @@ subprojects {
     JSR305: 'com.google.code.findbugs:jsr305:3.0.2', // transitively pulled in by GUAVA
 
     JIB_CORE: 'com.google.cloud.tools:jib-core:0.28.1',
-    JIB_GRADLE: 'com.google.cloud.tools:jib-gradle-plugin:3.5.1',
+    JIB_GRADLE: 'com.google.cloud.tools:jib-gradle-plugin:3.5.3',
 
     // for Build Plan and Jib Plugins Extension API
     JIB_GRADLE_EXTENSION: 'com.google.cloud.tools:jib-gradle-plugin-extension-api:0.4.0',


### PR DESCRIPTION
Update JIB Gradle plugin version to 3.5.3.